### PR TITLE
Bigger update than I thought

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 # Project Specific Files
 
-docker_test/Dockerfile
+docker_test/createrepo.json
 docker_test/.kurl
 docker_test/repo
-tests/integration/http_ca.crt
 http_ca.crt
 wtf.py
 

--- a/docker_test/common.bash
+++ b/docker_test/common.bash
@@ -10,6 +10,8 @@ ESUSR=elastic
 ENVFILE=.env
 CURLFILE=.kurl
 REPODOCKER=/media
+REPOJSON=createrepo.json
+REPONAME=testing
 LIMIT=30
 IMAGE=docker.elastic.co/elasticsearch/elasticsearch
 MEMORY=1GB  # The heap will be half of this
@@ -58,7 +60,7 @@ get_espw () {
     fi
 
     # Print the spinner to stderr (so it shows up)
-    printf "\r${spin:$s:1} ${seconds}s elapsed..." >&2
+    printf "\r${spin:$s:1} ${seconds}s elapsed (typically 15s - 25s)..." >&2
 
     # wait 1/10th of a second before looping again
     sleep 0.1
@@ -125,7 +127,7 @@ change_espw () {
 xpack_fork () {
 
   echo
-  echo "Getting credentials from the ${NAME} Elasticsearch container..."
+  echo "Getting Elasticsearch credentials from container \"${NAME}\"..."
   echo
 
   # Get the password from the change_espw function. It sets ESPWD
@@ -138,16 +140,22 @@ xpack_fork () {
   fi
 
   # Put envvars in ${ENVCFG}
+  echo "export ESCLIENT_USERNAME=${ESUSR}" >> ${ENVCFG}
   echo "export TEST_USER=${ESUSR}" >> ${ENVCFG}
   # We escape the quotes so we can include them in case of special characters
+  echo "export ESCLIENT_PASSWORD=\"${ESPWD}\"" >> ${ENVCFG}
   echo "export TEST_PASS=\"${ESPWD}\"" >> ${ENVCFG}
+
+
+  # Get the CA certificate and copy it to the PROJECT_ROOT
+  docker cp -q ${NAME}:/usr/share/elasticsearch/config/certs/http_ca.crt ${PROJECT_ROOT}
 
   # Put the credentials into ${CURLCFG}
   echo "-u ${ESUSR}:${ESPWD}" >> ${CURLCFG}
-  echo "-k" >> ${CURLCFG}
+  echo "--cacert ${CACRT}" >> ${CURLCFG}
 
-  # Get the CA certificate and copy it to the TESTPATH
-  docker cp -q ${NAME}:/usr/share/elasticsearch/config/certs/http_ca.crt ${TESTPATH}
+  # Complete
+  echo "Credentials captured!"
 }
 
 # Save original execution path
@@ -176,13 +184,12 @@ else
   TESTPATH=${SCRIPTPATH}
 fi
 
+# Set the CACRT var
+CACRT=${PROJECT_ROOT}/http_ca.crt
+
 # Set the .env file
 ENVCFG=${PROJECT_ROOT}/${ENVFILE}
-
-# Add TESTPATH to ${ENVCFG}, creating it or overwriting it
-echo "export TEST_PATH=${TESTPATH}" > ${ENVCFG}
-echo "export CA_CRT=${TESTPATH}/http_ca.crt" > ${ENVCFG}
-
+rm -rf ${ENVCFG}
 
 # Set the curl config file and ensure we're not reusing an old one
 CURLCFG=${SCRIPTPATH}/${CURLFILE}

--- a/docker_test/create.sh
+++ b/docker_test/create.sh
@@ -22,26 +22,17 @@ VERSION=${1}
 rm -rf ${REPOLOCAL}
 mkdir -p ${REPOLOCAL}
 
-###################
-### Build Image ###
-###################
-
-## Check if the image has been built. If not, build it.
-#if [[ "$(docker images -q ${IMAGE}:${VERSION} 2> /dev/null)" == "" ]]; then
-#  echo "Docker image ${IMAGE}:${VERSION} not found. Building from Dockerfile..."
-#  cd ${SCRIPTPATH}
-#  # Create a Dockerfile from the template
-#  cat Dockerfile.tmpl | sed -e "s/ES_VERSION/${VERSION}/" > Dockerfile
-#  docker build . -t ${IMAGE}:${VERSION}
-#fi
-
 #####################
 ### Run Container ###
 #####################
 
+docker network rm -f ${NAME}-net
+docker network create ${NAME}-net
+
 # Start the container
-echo -en "\rStarting ${NAME} container... "
-docker run -d -it --name ${NAME} -m ${MEMORY} \
+echo "Starting container \"${NAME}\" from ${IMAGE}:${VERSION}"
+echo -en "Container ID: "
+docker run -d -it --name ${NAME} --network ${NAME}-net -m ${MEMORY} \
   -p ${LOCAL_PORT}:${DOCKER_PORT} \
   -v ${REPOLOCAL}:${REPODOCKER} \
   -e "discovery.type=single-node" \
@@ -51,6 +42,18 @@ docker run -d -it --name ${NAME} -m ${MEMORY} \
   -e "path.repo=${REPODOCKER}" \
 ${IMAGE}:${VERSION}
 
+# Set the URL
+URL=https://${URL_HOST}:${LOCAL_PORT}
+
+# Add TESTPATH to ${ENVCFG}, creating it or overwriting it
+echo "export CA_CRT=${PROJECT_ROOT}/http_ca.crt" >> ${ENVCFG}
+echo "export TEST_PATH=${TESTPATH}" >> ${ENVCFG}
+echo "export TEST_ES_SERVER=${URL}" >> ${ENVCFG}
+echo "export TEST_ES_REPO=${REPONAME}" >> ${ENVCFG}
+
+# Write some ESCLIENT_ environment variables to the .env file  
+echo "export ESCLIENT_CA_CERTS=${CACRT}" >> ${ENVCFG}
+echo "export ESCLIENT_HOSTS=${URL}" >> ${ENVCFG}
 
 # Set up the curl config file, first line creates a new file, all others append
 echo "-o /dev/null" > ${CURLCFG}
@@ -68,17 +71,8 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-# Set the URL
-URL=https://${URL_HOST}:${LOCAL_PORT}
-
-# Write the TEST_ES_SERVER environment variable to the .env file
-echo "export TEST_ES_SERVER=${URL}" >> ${ENVCFG}
-
 # We expect a 200 HTTP rsponse
 EXPECTED=200
-
-# Set the NODE var
-NODE="${NAME} instance"
 
 # Start with an empty value
 ACTUAL=0
@@ -87,17 +81,19 @@ ACTUAL=0
 COUNTER=0
 
 # Loop until we get our 200 code
+echo
 while [ "${ACTUAL}" != "${EXPECTED}" ] && [ ${COUNTER} -lt ${LIMIT} ]; do
 
   # Get our actual response
   ACTUAL=$(curl -K ${CURLCFG} ${URL})
 
   # Report what we received
-  echo -en "\rHTTP status code for ${NODE} is: ${ACTUAL}"
+  echo -en "\rWaiting for Elasticsearch. HTTP Status Code: ${ACTUAL}"
 
   # If we got what we expected, we're great!
   if [ "${ACTUAL}" == "${EXPECTED}" ]; then
-    echo " --- ${NODE} is ready!"
+    echo
+    echo "Elasticsearch is ready!"
 
   else
     # Otherwise sleep and try again 
@@ -116,15 +112,63 @@ if [ "${ACTUAL}" != "${EXPECTED}" ]; then
 
 fi
 
+# Initialize trial license
+echo
+response=$(curl -s \
+  --cacert ${CACRT} -u "${ESUSR}:${ESPWD}" \
+  -XPOST "${URL}/_license/start_trial?acknowledge=true")
+
+expected='{"acknowledged":true,"trial_was_started":true,"type":"trial"}'
+if [ "$response" != "$expected" ]; then
+  echo "ERROR! Unable to start trial license!"
+else
+  echo -n "Trial license started and acknowledged. "
+fi
+
+# Set up snapshot repository. The following will create a JSON file suitable for use with
+# curl -d @filename
+
+rm -f ${REPOJSON}  
+
+echo    '{'                    >> $REPOJSON
+echo    '  "type": "fs",'      >> $REPOJSON
+echo    '  "settings": {'      >> $REPOJSON
+echo -n '    "location": "'    >> $REPOJSON
+echo -n "${REPODOCKER}"        >> $REPOJSON
+echo    '"'                    >> $REPOJSON
+echo    '  }'                  >> $REPOJSON
+echo    '}'                    >> $REPOJSON
+
+# Create snapshot repository
+response=$(curl -s \
+  --cacert ${CACRT} -u "${ESUSR}:${ESPWD}" \
+  -H 'Content-Type: application/json' \
+  -XPOST "${URL}/_snapshot/${REPONAME}?verify=false" \
+  --json \@${REPOJSON})
+
+expected='{"acknowledged":true}'
+if [ "$response" != "$expected" ]; then
+  echo "ERROR! Unable to create snapshot repository"
+else
+  echo "Snapshot repository \"${REPONAME}\" created."
+  # Put ESCLIENT_ env var export here?
+fi
+
+
 ##################
 ### Wrap it up ###
 ##################
 
 echo
-echo "${NAME} container is up using image elasticsearch:${VERSION}"
-
-echo
-echo "Environment variables are in \$PROJECT_ROOT/.env"
-
-echo
+echo "Elasticsearch container \"${NAME}\" is up!"
 echo "Ready to test!"
+echo
+
+if [ "$EXECPATH" == "$PROJECT_ROOT" ]; then
+  echo "Environment variables are in .env"
+elif [ "$EXECPATH" == "$SCRIPTPATH" ]; then
+  echo "\$PWD is $SCRIPTPATH." 
+  echo "Environment variables are in ../.env"
+else
+  echo "Environment variables are in ${PROJECT_ROOT}/.env"
+fi

--- a/docker_test/destroy.sh
+++ b/docker_test/destroy.sh
@@ -10,12 +10,15 @@ echo "$(docker stop ${NAME}) stopped."
 echo "Removing container ${NAME}..."
 echo "$(docker rm ${NAME}) deleted."
 
+echo "Removing Docker network ${NAME}-net..."
+docker network rm -f ${NAME}-net
+
 # Delete .env file and curl config file
 echo "Deleting remaining files and directories"
 rm -rf ${REPOLOCAL}
-rm -f ${SCRIPTPATH}/Dockerfile
+rm -f ${SCRIPTPATH}/${REPOJSON}
 rm -f ${ENVCFG}
 rm -f ${CURLCFG}
-rm -f ${TESTPATH}/http_ca.crt
+rm -f ${PROJECT_ROOT}/http_ca.crt
 
 echo "Cleanup complete."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,9 @@ keywords = [
     'snapshot',
 ]
 dependencies = [
+    'gitpython==3.1.43',
     'dotmap==1.3.30',
-    'es_client==8.13.4',
+    'es_client==8.13.5',
     'es-wait==0.7.2',
 ]
 
@@ -88,17 +89,14 @@ detached = true
 dependencies = [
   'black>=23.1.0',
   'mypy>=1.0.0',
-  'ruff>=0.0.243',
 ]
 [tool.hatch.envs.lint.scripts]
 typing = 'mypy --install-types --non-interactive {args:src/es_testbed tests}'
 style = [
-  'ruff {args:.}',
   'black --check --diff {args:.}',
 ]
 fmt = [
   'black {args:.}',
-  'ruff --fix {args:.}',
   'style',
 ]
 all = [
@@ -111,61 +109,6 @@ target-version = ['py38']
 line-length = 88
 skip-string-normalization = true
 include = '\.pyi?$'
-
-[tool.ruff]
-target-version = 'py38'
-line-length = 120
-select = [
-  'A',
-  'ARG',
-  'B',
-  'C',
-  'DTZ',
-  'E',
-  'EM',
-  'F',
-  'FBT',
-  'I',
-  'ICN',
-  'ISC',
-  'N',
-  'PLC',
-  'PLE',
-  'PLR',
-  'PLW',
-  'Q',
-  'RUF',
-  'S',
-  'T',
-  'TID',
-  'UP',
-  'W',
-  'YTT',
-]
-ignore = [
-  # Allow non-abstract empty methods in abstract base classes
-  'B027',
-  # Allow boolean positional values in function calls, like `dict.get(... True)`
-  'FBT003',
-  # Ignore checks for possible passwords
-  'S105', 'S106', 'S107',
-  # Ignore complexity
-  'C901', 'PLR0911', 'PLR0912', 'PLR0913', 'PLR0915',
-]
-unfixable = [
-  # Don't touch unused imports
-  'F401',
-]
-
-[tool.ruff.isort]
-known-first-party = ['es_testbed']
-
-[tool.ruff.flake8-tidy-imports]
-ban-relative-imports = 'all'
-
-[tool.ruff.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-'tests/**/*' = ['PLR2004', 'S101', 'TID252']
 
 [tool.coverage.run]
 source_pkgs = ['es_testbed', 'tests']

--- a/src/es_testbed/__init__.py
+++ b/src/es_testbed/__init__.py
@@ -1,6 +1,6 @@
 """Make classes easier to import here"""
 
-__version__ = '0.7.2'
+__version__ = '0.8.0'
 
 from es_testbed._base import TestBed
 from es_testbed._plan import PlanBuilder

--- a/src/es_testbed/_plan.py
+++ b/src/es_testbed/_plan.py
@@ -6,7 +6,7 @@ from dotmap import DotMap
 from es_testbed.defaults import TESTPLAN
 from es_testbed.helpers.utils import build_ilm_policy, prettystr, randomstr
 
-logger = logging.getLogger('es_testbed.PlanBuilder')
+logger = logging.getLogger(__name__)
 
 
 class PlanBuilder:
@@ -15,23 +15,22 @@ class PlanBuilder:
     def __init__(
         self,
         settings: t.Dict = None,
-        default_entities: bool = True,
         autobuild: t.Optional[bool] = True,
     ):
-        self.default_entities = default_entities
         if settings is None:
             raise ValueError('Must provide a settings dictionary')
         self.settings = settings
+        logger.debug('SETTINGS: %s', settings)
         self._plan = DotMap(TESTPLAN)
         logger.debug('INITIAL PLAN: %s', prettystr(self._plan))
-        self._plan.cleanup = 'UNKNOWN'  # Future use?
+        self._plan.cleanup = 'UNSET'  # Future use?
         if autobuild:
             self.setup()
 
         # ## Example settings
-        # settings={
+        # {
         #   'type': 'indices',       # Default is indices? Or should it be data_streams?
-        #   'prefix': 'es-testbed',  # Provide this value as a default
+        #   'prefix': 'es-testbed',  # The default prefix for everything we create
         #   'rollover_alias': False, # Only respected if 'type' == 'indices'.
         #                            # Will rollover after creation and filling 1st
         #                            # If True, will be overridden to value of alias
@@ -40,40 +39,45 @@ class PlanBuilder:
         #   'repository':            # Only used for cold/frozen tier for snapshots
         #   'ilm': {                 # All of these ILM values are defaults
         #     'enabled': False,
-        #     'tiers': ['hot', 'delete'],
+        #     'phases': ['hot', 'delete'],
+        #     'readonly': PHASE      # Define readonly action during named PHASE
         #     'forcemerge': False,
         #     'max_num_segments': 1,
+        #     'policy': {}           # Define full ILM policy in advance.
         #   }
         #
-        # # If these keys aren't specified per entity, then all entities will get this
-        # # treatment
-        # # EXCEPT for the is_write_index for aliases and data_streams
+
         #
-        #   'defaults': {
-        #     'entity_count': 3,
-        #     'docs': 10,
-        #     'match': True,
-        #     'searchable': tier...
-        #   }
-        #
-        # # Manually specifying entities makes sense for individual indices, but not so
-        # # much for
-        # # alias-backed indices or data_streams
-        #   'entities': [
+        # # The index_buildlist
+        # # The array of indices to build. Needs at least a single element. Importing
+        # # is expected, but it can be modified or replaced after importing.
+        #   'index_buildlist': [
         #    {
-        #      'docs': 10,
-        #      'match': True,
-        #      'searchable': 'frozen'
+        #      'preset': 'NAME',         # docgen_preset name, included or otherwise
+        #      'options': {              # kwargs for the generator function
+        #        'docs': 10,
+        #        'start_at': 0,
+        #        'match': True,
+        #      }
+        #      'target_tier': 'frozen'   # Target tier for 1st (oldest) index created
         #    },
         #    {
-        #      'docs': 10,
-        #      'match': False,
-        #      'searchable': 'cold',
+        #      'preset': 'NAME',         # docgen_preset name, included or otherwise
+        #      'options': {              # kwargs for the generator function
+        #        'docs': 10,
+        #        'start_at': 10,
+        #        'match': True,
+        #      }
+        #      'target_tier': 'cold'     # Target tier for 2nd index created
         #    },
         #    {
-        #      'docs': 10,
-        #      'match': True,
-        #      'searchable': 'hot'
+        #      'preset': 'NAME',         # docgen_preset name, included or otherwise
+        #      'options': {              # kwargs for the generator function
+        #        'docs': 10,
+        #        'start_at': 20,
+        #        'match': True,
+        #      }
+        #      'target_tier': 'hot'      # Target tier for last (newest) index created
         #    },
         #   ]
         # }
@@ -95,33 +99,6 @@ class PlanBuilder:
         for name in names:
             self._plan[name] = []
 
-    def add_entity(
-        self,
-        docs: t.Optional[int] = 10,
-        match: t.Optional[bool] = True,
-        searchable: t.Optional[str] = None,
-    ) -> None:
-        """Add an index or data_stream"""
-        entity = DotMap({'docs': docs, 'match': match})
-        if searchable:
-            entity.searchable = searchable
-        self._plan.entities.append(entity)
-
-    def make_default_entities(self) -> None:
-        """Loop through until all entities are created"""
-        defs = TESTPLAN['defaults']  # Start with defaults
-        if 'defaults' in self._plan:
-            defs = self._plan.defaults
-        kwargs = {
-            'docs': defs['docs'],
-            'match': defs['match'],
-            'searchable': defs['searchable'],
-        }
-        self._plan.entities = []
-        for _ in range(0, defs['entity_count']):
-            self.add_entity(**kwargs)
-        logger.debug('Plan will create %s (backing) indices', len(self._plan.entities))
-
     def setup(self) -> None:
         """Do initial setup of the Plan DotMap"""
         self._plan.uniq = randomstr(length=8, lowercase=True)
@@ -130,10 +107,7 @@ class PlanBuilder:
         self.update_rollover_alias()
         logger.debug('Rollover alias updated')
         self.update_ilm()
-        if not self._plan.entities:
-            if self.default_entities:
-                self.make_default_entities()
-        logger.debug('Test Plan: %s', prettystr(self._plan.toDict()))
+        logger.debug('FINAL PLAN: %s', prettystr(self._plan.toDict()))
 
     def update(self, settings: t.Dict) -> None:
         """Update the Plan DotMap"""
@@ -167,19 +141,23 @@ class PlanBuilder:
             self._plan.ilm = DotMap(TESTPLAN['ilm'])
         if self._plan.ilm.enabled:
             ilm = self._plan.ilm
-            if not isinstance(self._plan.ilm.tiers, list):
-                logger.error('Tiers is not a list!')
-                self._plan.ilm.tiers = TESTPLAN['ilm']['tiers']
-            for entity in self._plan.entities:
+            if not isinstance(self._plan.ilm.phases, list):
+                logger.error('Phases is not a list!')
+                self._plan.ilm.phases = TESTPLAN['ilm']['phases']
+            for entity in self._plan.index_buildlist:
                 if 'searchable' in entity and entity['searchable'] is not None:
-                    if not entity['searchable'] in ilm.tiers:
-                        ilm.tiers.append(entity['searchable'])
+                    if not entity['searchable'] in ilm.phases:
+                        ilm.phases.append(entity['searchable'])
+            logger.debug('ILM = %s', ilm)
+            logger.debug('self._plan.ilm = %s', self._plan.ilm)
             kwargs = {
-                'tiers': ilm.tiers,
+                'phases': ilm.phases,
                 'forcemerge': ilm.forcemerge,
                 'max_num_segments': ilm.max_num_segments,
+                'readonly': ilm.readonly,
                 'repository': self._plan.repository,
             }
+            logger.debug('KWARGS = %s', kwargs)
             self._plan.ilm.policy = build_ilm_policy(**kwargs)
 
     def update_rollover_alias(self) -> None:

--- a/src/es_testbed/defaults.py
+++ b/src/es_testbed/defaults.py
@@ -31,6 +31,7 @@ MAPPING: dict = {
 
 NAMEMAPPER: t.Dict[str, str] = {
     'index': 'idx',
+    'indices': 'idx',  # This is to aid testing and other places where kind is indices
     'data_stream': 'ds',
     'component': 'cmp',
     'ilm': 'ilm',
@@ -53,15 +54,10 @@ TESTPLAN: dict = {
     'rollover_alias': None,
     'ilm': {
         'enabled': False,
-        'tiers': ['hot', 'delete'],
+        'phases': ['hot', 'delete'],
+        'readonly': None,
         'forcemerge': False,
         'max_num_segments': 1,
-    },
-    'defaults': {
-        'entity_count': 3,
-        'docs': 10,
-        'match': True,
-        'searchable': None,
     },
     'entities': [],
 }
@@ -114,8 +110,8 @@ def ilmdelete() -> IlmPhase:
     return {'min_age': '5d', 'actions': {'delete': {}}}
 
 
-def ilm_phase(tier):
-    """Return the default phase step based on 'tier'"""
+def ilm_phase(value):
+    """Return the default phase step based on 'value'"""
     phase_map = {
         'hot': ilmhot(),
         'warm': ilmwarm(),
@@ -123,7 +119,7 @@ def ilm_phase(tier):
         'frozen': ilmfrozen(),
         'delete': ilmdelete(),
     }
-    return {tier: phase_map[tier]}
+    return {value: phase_map[value]}
 
 
 def ilm_force_merge(max_num_segments=1):

--- a/src/es_testbed/entities/index.py
+++ b/src/es_testbed/entities/index.py
@@ -162,10 +162,10 @@ class Index(Entity):
         If we are NOT using ILM but have specified searchable snapshots in the plan
         entities
         """
-        if 'searchable' in scheme and scheme['searchable'] is not None:
-            self.snapmgr.add(self.name, scheme['searchable'])
+        if 'target_tier' in scheme and scheme['target_tier'] in ['cold', 'frozen']:
+            self.snapmgr.add(self.name, scheme['target_tier'])
             # Replace self.name with the renamed name
-            self.name = mounted_name(self.name, scheme['searchable'])
+            self.name = mounted_name(self.name, scheme['target_tier'])
 
     def mount_ss(self, scheme: dict) -> None:
         """If the index is planned to become a searchable snapshot, we do that now"""

--- a/src/es_testbed/helpers/es_api.py
+++ b/src/es_testbed/helpers/es_api.py
@@ -14,7 +14,6 @@ from ..exceptions import (
     TimeoutException,
 )
 from ..helpers.utils import (
-    doc_gen,
     get_routing,
     mounted_name,
     prettystr,
@@ -104,7 +103,7 @@ def create_data_stream(client: 'Elasticsearch', name: str) -> None:
     """Create a datastream"""
     try:
         client.indices.create_data_stream(name=name)
-        test = Exists(client, name=name, kind='datastream', pause=PAUSE_VALUE)
+        test = Exists(client, name=name, kind='data_stream', pause=PAUSE_VALUE)
         test.wait()
     except Exception as err:
         raise TestbedFailure(
@@ -233,30 +232,21 @@ def exists(
 def fill_index(
     client: 'Elasticsearch',
     name: t.Union[str, None] = None,
-    count: t.Union[int, None] = None,
-    start_num: t.Union[int, None] = None,
-    match: bool = True,
+    doc_generator: t.Union[t.Generator[t.Dict, None, None], None] = None,
+    options: t.Union[t.Dict, None] = None,
 ) -> None:
     """
     Create and fill the named index with mappings and settings as directed
 
     :param client: ES client
     :param name: Index name
-    :param count: The number of docs to create
-    :param start_number: Where to start the incrementing number
-    :param match: Whether to use the default values for key (True) or random strings
-        (False)
+    :param doc_generator: The generator function
 
-    :type client: es
-    :type name: str
-    :type count: int
-    :type start_number: int
-    :type match: bool
-
-    :rtype: None
     :returns: No return value
     """
-    for doc in doc_gen(count=count, start_at=start_num, match=match):
+    if not options:
+        options = {}
+    for doc in doc_generator(**options):
         client.index(index=name, document=doc)
     client.indices.flush(index=name)
     client.indices.refresh(index=name)

--- a/src/es_testbed/helpers/utils.py
+++ b/src/es_testbed/helpers/utils.py
@@ -1,100 +1,109 @@
 """Utility helper functions"""
 
+import sys
 import typing as t
-from pprint import pformat
 import random
 import string
 import logging
 from datetime import datetime, timezone
-from ..defaults import ilm_force_merge, ilm_phase, MAPPING, TIER
+from pathlib import Path
+from pprint import pformat
+from shutil import rmtree
+from tempfile import mkdtemp
+from git import Repo
+from ..defaults import ilm_force_merge, ilm_phase, TIER
 from ..exceptions import TestbedMisconfig
 
 logger = logging.getLogger(__name__)
 
 
 def build_ilm_phase(
-    tier: str,
+    phase: str,
     actions: t.Union[t.Dict, None] = None,
     repo: t.Union[str, None] = None,
     fm: bool = False,
 ) -> t.Dict:
-    """Build a single ILM policy step based on tier"""
-    phase = ilm_phase(tier)
-    if tier in ['cold', 'frozen']:
+    """Build a single ILM policy step based on phase"""
+    retval = ilm_phase(phase)
+    if phase in ['cold', 'frozen']:
         if repo:
-            phase[tier]['actions']['searchable_snapshot'] = {
+            retval[phase]['actions']['searchable_snapshot'] = {
                 'snapshot_repository': repo,
                 'force_merge_index': fm,
             }
         else:
             msg = (
-                f'Unable to build ILM phase for {tier} tier. Value for repository not '
+                f'Unable to build {phase} ILM phase. Value for repository not '
                 f'provided'
             )
             raise TestbedMisconfig(msg)
     if actions:
-        phase[tier]['actions'].update(actions)
-    return phase
+        retval[phase]['actions'].update(actions)
+    return retval
 
 
 def build_ilm_policy(
-    tiers: list = None,
+    phases: list = None,
     forcemerge: bool = False,
     max_num_segments: int = 1,
-    repository: str = None,
+    readonly: t.Union[str, None] = None,
+    repository: t.Union[str, None] = None,
 ) -> t.Dict:
     """
-    Build a full ILM policy based on the provided tiers.
-    Put forcemerge in the last tier before cold or frozen (whichever comes first)
+    Build a full ILM policy based on the provided phases.
+    Put forcemerge in the last phase before cold or frozen (whichever comes first)
     """
-    if not tiers:
-        tiers = ['hot', 'delete']
-    phases = {}
-    if ('cold' in tiers or 'frozen' in tiers) and not repository:
+    if not phases:
+        phases = ['hot', 'delete']
+    retval = {}
+    if ('cold' in phases or 'frozen' in phases) and not repository:
         raise TestbedMisconfig('Cannot build cold or frozen phase without repository')
-    for tier in tiers:
-        phase = build_ilm_phase(tier, repo=repository, fm=forcemerge)
-        phases.update(phase)
+    for phase in phases:
+        actions = None
+        if readonly == phase:
+            actions = {"readonly": {}}
+        phase = build_ilm_phase(phase, repo=repository, fm=forcemerge, actions=actions)
+        retval.update(phase)
     if forcemerge:
-        phases['hot']['actions'].update(
+        retval['hot']['actions'].update(
             ilm_force_merge(max_num_segments=max_num_segments)
         )
-    return {'phases': phases}
+    return {'phases': retval}
 
 
-def doc_gen(
-    count: int = 10, start_at: int = 0, match: bool = True
-) -> t.Generator[t.Dict, None, None]:
-    """Create this doc for each count"""
-    keys = ['message', 'nested', 'deep']
-    # Start with an empty map
-    matchmap = {}
-    # Iterate over each key
-    for key in keys:
-        # If match is True
-        if match:
-            # Set matchmap[key] to key
-            matchmap[key] = key
-        else:
-            # Otherwise matchmap[key] will have a random string value
-            matchmap[key] = randomstr()
+# def doc_gen(
+#     count: int = 10, start_at: int = 0, match: bool = True
+# ) -> t.Generator[t.Dict, None, None]:
+#     """Create this doc for each count"""
+#     keys = ['message', 'nested', 'deep']
+#     # Start with an empty map
+#     matchmap = {}
+#     # Iterate over each key
+#     for key in keys:
+#         # If match is True
+#         if match:
+#             # Set matchmap[key] to key
+#             matchmap[key] = key
+#         else:
+#             # Otherwise matchmap[key] will have a random string value
+#             matchmap[key] = randomstr()
 
-    # This is where count and start_at matter
-    for num in range(start_at, start_at + count):
-        yield {
-            '@timestamp': iso8601_now(),
-            'message': f'{matchmap["message"]}{num}',  # message# or randomstr#
-            'number': (
-                num if match else random.randint(1001, 32767)
-            ),  # value of num or random int
-            'nested': {'key': f'{matchmap["nested"]}{num}'},  # nested#
-            'deep': {'l1': {'l2': {'l3': f'{matchmap["deep"]}{num}'}}},  # deep#
-        }
+#     # This is where count and start_at matter
+#     for num in range(start_at, start_at + count):
+#         yield {
+#             '@timestamp': iso8601_now(),
+#             'message': f'{matchmap["message"]}{num}',  # message# or randomstr#
+#             'number': (
+#                 num if match else random.randint(1001, 32767)
+#             ),  # value of num or random int
+#             'nested': {'key': f'{matchmap["nested"]}{num}'},  # nested#
+#             'deep': {'l1': {'l2': {'l3': f'{matchmap["deep"]}{num}'}}},  # deep#
+#         }
 
 
-def getlogger(name: str) -> logging.getLogger:
-    """Return a named logger"""
-    return logging.getLogger(name)
+# def getlogger(name: str) -> logging.getLogger:
+#     """Return a named logger"""
+#     return logging.getLogger(name)
 
 
 def get_routing(tier='hot') -> t.Dict:
@@ -140,11 +149,6 @@ def iso8601_now() -> str:
     return f'{parts[0]}+{parts[1]}'  # Fallback publishes the +TZ, whatever that was
 
 
-def mapping_component() -> t.Dict:
-    """Return a mappings component template"""
-    return {'mappings': MAPPING}
-
-
 def mounted_name(index: str, tier: str):
     """Return a value for renamed_index for mounting a searchable snapshot index"""
     return f'{TIER[tier]["prefix"]}-{index}'
@@ -176,24 +180,64 @@ def prettystr(*args, **kwargs) -> str:
     return f"\n{pformat(*args, **kw)}"  # newline in front so it always starts clean
 
 
+def process_preset(
+    builtin: t.Union[str, None],
+    path: t.Union[str, None],
+    ref: t.Union[str, None],
+    url: t.Union[str, None],
+) -> t.Tuple:
+    """Process the preset settings
+    :param preset: One of `builtin`, `git`, or `path`
+    :param builtin: The name of a builtin preset
+    :param path: A relative or absolute file path. Used by presets `git` and `path`
+    :param ref: A Git ref (e.g. 'main'). Only used by preset `git`
+    :param url: A Git repository URL. Only used by preset `git`
+    """
+    modpath = None
+    tmpdir = None
+    if builtin:  # Overrides any other options
+        modpath = f'es_testbed.presets.{builtin}'
+    else:
+        trygit = False
+        try:
+            kw = {'path': path, 'ref': ref, 'url': url}
+            raise_on_none(**kw)
+            trygit = True  # We have all 3 kwargs necessary for git
+        except ValueError as resp:  # Not able to do a git preset
+            logger.debug('Unable to import a git-based preset: %s', resp)
+        if trygit:  # Trying a git import
+            tmpdir = mkdtemp()
+            try:
+                _ = Repo.clone_from(url, tmpdir, branch=ref, depth=1)
+                filepath = Path(tmpdir) / path
+            except Exception as err:
+                logger.error('Git clone failed: %s', err)
+                rmtree(tmpdir)  # Clean up after failed attempt
+                raise err
+        if path:
+            filepath = Path(path)
+        if not filepath.resolve().is_dir():
+            raise ValueError(f'The provided path "{path}" is not a directory')
+        modpath = filepath.resolve().name  # The final dirname
+        parent = filepath.parent.resolve()  # Up one level
+        # We now make the parent path part of the sys.path.
+        sys.path.insert(0, parent)  # This should persist beyond this module
+    return modpath, tmpdir
+
+
+def raise_on_none(**kwargs):
+    """Raise if any kwargs have a None value"""
+    for key, value in kwargs.items():
+        if value is None:
+            raise ValueError(f'kwarg "{key}" cannot have a None value')
+
+
 def randomstr(length: int = 16, lowercase: bool = False) -> str:
     """Generate a random string"""
     letters = string.ascii_uppercase
     if lowercase:
         letters = string.ascii_lowercase
     return str(''.join(random.choices(letters + string.digits, k=length)))
-
-
-def setting_component(
-    ilm_policy: t.Union[str, None] = None, rollover_alias: t.Union[str, None] = None
-) -> t.Dict[str, t.Any]:
-    """Return a settings component template"""
-    val = {'settings': {'index.number_of_replicas': 0}}
-    if ilm_policy:
-        val['settings']['index.lifecycle.name'] = ilm_policy
-    if rollover_alias:
-        val['settings']['index.lifecycle.rollover_alias'] = rollover_alias
-    return val
 
 
 def storage_type(tier: str) -> t.Dict:

--- a/src/es_testbed/mgrs/ilm.py
+++ b/src/es_testbed/mgrs/ilm.py
@@ -31,9 +31,10 @@ class IlmMgr(EntityMgr):
         """Return the configured ILM policy"""
         d = self.plan.ilm
         kwargs = {
-            'tiers': d.tiers,
+            'phases': d.phases,
             'forcemerge': d.forcemerge,
             'max_num_segments': d.max_num_segments,
+            'readonly': d.readonly,
             'repository': self.plan.repository,
         }
         return build_ilm_policy(**kwargs)
@@ -42,7 +43,8 @@ class IlmMgr(EntityMgr):
         """Setup the entity manager"""
         logger.debug('Starting IlmMgr setup...')
         if self.plan.ilm.enabled:
-            self.plan.ilm.policy = self.get_policy()
+            if not self.plan.ilm.policy:  # If you've put a full policy there...
+                self.plan.ilm.policy = self.get_policy()
             put_ilm(self.client, self.name, policy=self.plan.ilm.policy)
             # Verify existence
             if not exists(self.client, 'ilm', self.name):

--- a/src/es_testbed/presets/searchable_test/buildlist.yml
+++ b/src/es_testbed/presets/searchable_test/buildlist.yml
@@ -1,0 +1,17 @@
+---
+index_buildlist:
+  - options:
+      count: 10
+      start_at: 0
+      match: True
+    target_tier: hot
+  - options:
+      count: 10
+      start_at: 10
+      match: True
+    target_tier: hot
+  - options:
+      count: 10
+      start_at: 20
+      match: True
+    target_tier: hot

--- a/src/es_testbed/presets/searchable_test/definitions.py
+++ b/src/es_testbed/presets/searchable_test/definitions.py
@@ -1,0 +1,50 @@
+"""Searchable Snapshot Test Built-in Plan"""
+
+import logging
+from pathlib import Path
+from json import loads
+from es_client.helpers.utils import get_yaml
+from . import scenarios
+
+logger = logging.getLogger(__name__)
+
+
+def baseplan() -> dict:
+    """Return the base plan object from plan.yml"""
+    return get_yaml((modpath() / 'plan.yml'))
+
+
+def buildlist() -> list:
+    """Return the list of index build schemas from buildlist.yml"""
+    return get_yaml((modpath() / 'buildlist.yml'))
+
+
+def get_plan(scenario: str = None) -> dict:
+    """Return the plan dict based on scenario"""
+    retval = baseplan()
+    retval.update(buildlist())
+    if not scenario:
+        return retval
+    newvals = getattr(scenarios, scenario)
+    ilm = {}
+    if 'ilm' in newvals:
+        ilm = newvals.pop('ilm')
+    if ilm:
+        retval['ilm'].update(ilm)
+    retval.update(newvals)
+    return retval
+
+
+def mappings() -> dict:
+    """Return the index mappings from mappings.json"""
+    return loads((modpath() / 'mappings.json').read_text(encoding='UTF-8'))
+
+
+def modpath() -> Path:
+    """Return the local file path"""
+    return Path(__file__).parent.resolve()
+
+
+def settings() -> dict:
+    """Return the index settings from settings.json"""
+    return loads((modpath() / 'settings.json').read_text(encoding='UTF-8'))

--- a/src/es_testbed/presets/searchable_test/functions.py
+++ b/src/es_testbed/presets/searchable_test/functions.py
@@ -1,0 +1,94 @@
+"""Module that will generate docs for Searchable Snapshot Test"""
+
+import typing as t
+import random
+import string
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+def iso8601_now() -> str:
+    """
+    :returns: An ISO8601 timestamp based on now
+    :rtype: str
+
+    Because Python 3.12 now requires non-naive timezone declarations, we must change.
+
+    The new way:
+
+    .. code-block:: python
+
+      datetime.now(timezone.utc).isoformat()
+
+    Result: ``2024-04-16T16:00:00+00:00``
+
+    Note that the +00:00 is appended now where we affirmatively declare the
+    UTC timezone
+
+    As a result, we will use this function to prune away the timezone if it is
+    +00:00 and replace it with Z, which is shorter Zulu notation for UTC (which
+    Elasticsearch uses)
+
+    We are MANUALLY, FORCEFULLY declaring timezone.utc, so it should ALWAYS be
+    +00:00, but could in theory sometime show up as a Z, so we test for that.
+    """
+
+    parts = datetime.now(timezone.utc).isoformat().split('+')
+    if len(parts) == 1:
+        if parts[0][-1] == 'Z':
+            return parts[0]  # _______ It already ends with a Z for Zulu/UTC time
+        return f'{parts[0]}Z'  # _____ It doesn't end with a Z so we put one there
+    if parts[1] == '00:00':
+        return f'{parts[0]}Z'  # _____ It doesn't end with a Z so we put one there
+    return f'{parts[0]}+{parts[1]}'  # Fallback publishes the +TZ, whatever that was
+
+
+def randomstr(length: int = 16, lowercase: bool = False) -> str:
+    """
+    :param length: The length of the random string
+    :param lowercase: Whether to force the string to lowercase
+    :returns: A random string of letters and numbers based on `length` and `lowercase`
+    """
+    letters = string.ascii_uppercase
+    if lowercase:
+        letters = string.ascii_lowercase
+    return str(''.join(random.choices(letters + string.digits, k=length)))
+
+
+def doc_generator(
+    count: int = 10, start_at: int = 0, match: bool = True
+) -> t.Generator[t.Dict, None, None]:
+    """
+    :param count: Create this many docs
+    :param start_at: Append value starts with this value
+    :param match: Do we want fieldnames to match between docgen runs, or be random?
+        Also affects document document field "number" (value will be incremental if
+        match is True, a random value between 1001 and 32767 if False)
+    :returns: A generator shipping docs
+    """
+    keys = ['message', 'nested', 'deep']
+    # Start with an empty map
+    matchmap = {}
+    # Iterate over each key
+    for key in keys:
+        # If match is True
+        if match:
+            # Set matchmap[key] to key
+            matchmap[key] = key
+        else:
+            # Otherwise matchmap[key] will have a random string value
+            matchmap[key] = randomstr()
+
+    # This is where count and start_at matter
+    for num in range(start_at, start_at + count):
+        yield {
+            '@timestamp': iso8601_now(),
+            'message': f'{matchmap["message"]}{num}',  # message# or randomstr#
+            'number': (
+                num if match else random.randint(1001, 32767)
+            ),  # value of num or random int
+            'nested': {'key': f'{matchmap["nested"]}{num}'},  # nested#
+            'deep': {'l1': {'l2': {'l3': f'{matchmap["deep"]}{num}'}}},  # deep#
+        }

--- a/src/es_testbed/presets/searchable_test/mappings.json
+++ b/src/es_testbed/presets/searchable_test/mappings.json
@@ -1,0 +1,17 @@
+{
+  "mappings": {
+    "properties": {
+      "@timestamp": {"type": "date"},
+      "message": {"type": "keyword"},
+      "number": {"type": "long"},
+      "nested": {"properties": {"key": {"type": "keyword"}}},
+      "deep": {
+        "properties": {
+          "l1": {
+            "properties": {"l2": {"properties": {"l3": {"type": "keyword"}}}}
+          }
+        }
+      }
+    }
+  }
+} 

--- a/src/es_testbed/presets/searchable_test/plan.yml
+++ b/src/es_testbed/presets/searchable_test/plan.yml
@@ -1,0 +1,11 @@
+---
+# Default values that can be overriden by scenarios
+type: indices
+rollover_alias: False
+repository: testing
+ilm:
+  enabled: False
+  phases: [hot, delete]
+  readonly: None
+  max_num_segments: 1
+  forcemerge: False

--- a/src/es_testbed/presets/searchable_test/scenarios.py
+++ b/src/es_testbed/presets/searchable_test/scenarios.py
@@ -1,0 +1,114 @@
+"""
+Searchable Snapshot Test Scenarios
+
+We use deepcopy to ensure that other scenarios changes don't propagate. We can't use
+constants as the values need to be changed, so deepcopy has us covered.
+
+The repository should be configurable at runtime, so we make it use the TEST_ES_REPO
+env var.
+"""
+
+from os import environ
+from copy import deepcopy
+
+REPOSITORY = environ.get('TEST_ES_REPO', 'found-snapshots')
+
+# default values = {
+#     'type': 'indices',
+#     'rollover_alias': False,
+#     'repository': REPOSITORY,
+#     'ilm': {
+#         'enabled': False,
+#         'phases': ['hot', 'delete'],
+#         'readonly': None,
+#         'max_num_segments': 1,
+#         'forcemerge': False,
+#     },
+# }
+
+bl = [
+    {
+        'options': {
+            'count': 10,
+            'start_at': 0,
+            'match': True,
+        },
+        'target_tier': 'frozen',
+    },
+    {
+        'options': {
+            'count': 10,
+            'start_at': 10,
+            'match': True,
+        },
+        'target_tier': 'frozen',
+    },
+    {
+        'options': {
+            'count': 10,
+            'start_at': 20,
+            'match': True,
+        },
+        'target_tier': 'hot',
+    },
+]
+
+# #####################
+# ### Hot Scenarios ###
+# #####################
+
+hot = {}  # The default
+hot_rollover = {'rollover_alias': True}
+hot_ds = {'type': 'data_stream'}
+
+# ######################
+# ### Cold Scenarios ###
+# ######################
+
+# Define the basic cold scenario
+cold = {'repository': REPOSITORY, 'index_buildlist': deepcopy(bl)}
+cold['index_buildlist'][0]['target_tier'] = 'cold'
+cold['index_buildlist'][1]['target_tier'] = 'cold'
+cold['index_buildlist'][2]['target_tier'] = 'cold'
+
+# Define the rollover_alias cold scenario
+cold_rollover = deepcopy(cold)
+cold_rollover['index_buildlist'][2]['target_tier'] = 'hot'
+cold_rollover['rollover_alias'] = True
+
+# Define the cold ILM scenario
+cold_ilm = {
+    'repository': REPOSITORY,
+    'rollover_alias': True,
+    'ilm': {'enabled': True, 'phases': ['hot', 'cold', 'delete']},
+}
+
+# Define the cold data_stream scenario
+cold_ds = deepcopy(cold_ilm)
+cold_ds['type'] = 'data_stream'
+
+# ########################
+# ### Frozen Scenarios ###
+# ########################
+
+# Define the basic frozen scenario
+frozen = {'repository': REPOSITORY, 'index_buildlist': deepcopy(bl)}
+frozen['index_buildlist'][0]['target_tier'] = 'frozen'
+frozen['index_buildlist'][1]['target_tier'] = 'frozen'
+frozen['index_buildlist'][2]['target_tier'] = 'frozen'
+
+# Define the rollover_alias frozen scenario
+frozen_rollover = deepcopy(frozen)
+frozen_rollover['index_buildlist'][2]['target_tier'] = 'hot'
+frozen_rollover['rollover_alias'] = True
+
+# Define the frozen ILM scenario
+frozen_ilm = {
+    'repository': REPOSITORY,
+    'rollover_alias': True,
+    'ilm': {'enabled': True, 'phases': ['hot', 'frozen', 'delete']},
+}
+
+# Define the frozen data_stream scenario
+frozen_ds = deepcopy(frozen_ilm)
+frozen_ds['type'] = 'data_stream'

--- a/src/es_testbed/presets/searchable_test/settings.json
+++ b/src/es_testbed/presets/searchable_test/settings.json
@@ -1,0 +1,7 @@
+{
+  "settings": {
+    "index": {
+      "number_of_replicas": 0
+    }
+  }
+} 

--- a/tests/integration/test_cold.py
+++ b/tests/integration/test_cold.py
@@ -2,51 +2,26 @@
 
 from . import TestAny
 
-SSTIER = 'cold'
-REPOTEST = True
-ILM = {
-    'enabled': True,
-    'tiers': ['hot', SSTIER, 'delete'],
-    'forcemerge': False,
-    'max_num_segments': 1,
-}
-
 
 class TestDataStream(TestAny):
     """TestDataStream"""
 
-    sstier = SSTIER
-    kind = 'data_stream'
-    roll = False
-    repo_test = REPOTEST
-    ilm = ILM
+    scenario = 'cold_ds'
 
 
 class TestIndices(TestAny):
     """TestIndices"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = False
-    repo_test = REPOTEST
-    ilm = {'enabled': False}
+    scenario = 'cold'
 
 
 class TestRolloverIndices(TestAny):
     """TestRolloverIndices"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = True
-    repo_test = REPOTEST
-    ilm = {'enabled': False}
+    scenario = 'cold_rollover'
 
 
 class TestRolloverIndicesILM(TestAny):
     """TestRolloverIndicesILM"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = True
-    repo_test = REPOTEST
-    ilm = ILM
+    scenario = 'cold_ilm'

--- a/tests/integration/test_frozen.py
+++ b/tests/integration/test_frozen.py
@@ -2,51 +2,26 @@
 
 from . import TestAny
 
-SSTIER = 'frozen'
-REPOTEST = True
-ILM = {
-    'enabled': True,
-    'tiers': ['hot', SSTIER, 'delete'],
-    'forcemerge': False,
-    'max_num_segments': 1,
-}
-
 
 class TestDataStream(TestAny):
     """TestDataStream"""
 
-    sstier = SSTIER
-    kind = 'data_stream'
-    roll = False
-    repo_test = REPOTEST
-    ilm = ILM
+    scenario = 'frozen_ds'
 
 
 class TestIndices(TestAny):
     """TestIndices"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = False
-    repo_test = REPOTEST
-    ilm = {'enabled': False}
+    scenario = 'frozen'
 
 
 class TestRolloverIndices(TestAny):
     """TestRolloverIndices"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = True
-    repo_test = REPOTEST
-    ilm = {'enabled': False}
+    scenario = 'frozen_rollover'
 
 
 class TestRolloverIndicesILM(TestAny):
     """TestRolloverIndicesILM"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = True
-    repo_test = REPOTEST
-    ilm = ILM
+    scenario = 'frozen_ilm'

--- a/tests/integration/test_hot.py
+++ b/tests/integration/test_hot.py
@@ -2,34 +2,20 @@
 
 from . import TestAny
 
-SSTIER = 'hot'
-
 
 class TestDataStream(TestAny):
     """TestDataStream"""
 
-    sstier = SSTIER
-    kind = 'data_stream'
-    roll = False
-    repo_test = False
-    ilm = {'enabled': False}
+    scenario = 'hot_ds'
 
 
 class TestIndices(TestAny):
     """TestIndices"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = False
-    repo_test = False
-    ilm = {'enabled': False}
+    scenario = 'hot'
 
 
 class TestRolloverIndices(TestAny):
     """TestRolloverIndices"""
 
-    sstier = SSTIER
-    kind = 'indices'
-    roll = True
-    repo_test = False
-    ilm = {'enabled': False}
+    scenario = 'hot_rollover'


### PR DESCRIPTION
While this does, indeed, add the readonly step to ILM, it also completely migrated the document generation to a new framework, that of presets.

A preset can be builtin, imported by path, or from a git repository. A preset must contain its own generator function called doc_generator, which will yield whatever documents you've configured to the `filler` function, which simply ships them to Elasticsearch. The filler function hasn't adapted to using bulk requests yet, but it probably should in the next iteration.

A preset contains a plan, the index_buildlist array of settings per index, definitions, index mappings & settings, and optionally multiple scenarios.  It literally becomes an importable python module with supporting files.

Tests were updated, as were the mgrs an entities, base class and plan class. A rather largish change.

I'm not yet at 1.0.0. I'm able to do this if I want.