### PR TITLE
Lots of small changes:

### DIFF
--- a/docker_test/VERSION
+++ b/docker_test/VERSION
@@ -1,4 +1,4 @@
-Version: 1.0.2
-Released: 23 August 2024
+Version: 1.1.0
+Released: 24 August 2024
 
 # License and Changelog at https://github.com/untergeek/es-docker-test-scripts

--- a/docker_test/env_var.yaml
+++ b/docker_test/env_var.yaml
@@ -1,0 +1,8 @@
+---
+elasticsearch:
+  client:
+    hosts: ${ESCLIENT_HOSTS}
+    ca_certs: ${ESCLIENT_CA_CERTS}
+  other_settings:
+    username: ${ESCLIENT_USERNAME}
+    password: ${ESCLIENT_PASSWORD}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ cov = [
   'cov-report',
 ]
 
-[[tool.hatch.envs.all.matrix]]
+[[tool.hatch.envs.test.matrix]]
 python = ['3.8', '3.9', '3.10', '3.11', '3.12']
 
 [tool.hatch.envs.test.scripts]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-log_cli=true
+log_cli=false
 env_files =
     .env
 log_format = %(asctime)s %(levelname)-9s %(name)22s %(funcName)22s:%(lineno)-4d %(message)s

--- a/src/es_testbed/__init__.py
+++ b/src/es_testbed/__init__.py
@@ -1,6 +1,6 @@
 """Make classes easier to import here"""
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 
 from es_testbed._base import TestBed
 from es_testbed._plan import PlanBuilder

--- a/src/es_testbed/defaults.py
+++ b/src/es_testbed/defaults.py
@@ -80,7 +80,20 @@ TIER: dict = {
 TIMEOUT_DEFAULT: str = '30'
 TIMEOUT_ENVVAR: str = 'ES_TESTBED_TIMEOUT'
 
-IlmPhase: t.TypeAlias = t.Dict[
+# Define IlmPhase as a typing alias to be reused multiple times
+#
+# In all currently supported Python versions (3.8 -> 3.12), the syntax:
+#
+#   IlmPhase = t.Dict[
+#
+# is supported. In 3.10 and up, you can use the more explicit syntax:
+#
+#   IlmPhase: t.TypeAlias = t.Dict[
+#
+# making use of the TypeAlias class.
+#
+# To support Python versions 3.8 and 3.9 (still), the older syntax is used.
+IlmPhase = t.Dict[
     str, t.Union[str, t.Dict[str, str], t.Dict[str, t.Dict[str, t.Dict[str, str]]]]
 ]
 

--- a/src/es_testbed/helpers/utils.py
+++ b/src/es_testbed/helpers/utils.py
@@ -163,6 +163,9 @@ def prettystr(*args, **kwargs) -> str:
     'Return the formatted representation of object as a string. indent, width, depth,
     compact, sort_dicts and underscore_numbers are passed to the PrettyPrinter
     constructor as formatting parameters' (from pprint documentation).
+
+    The keyword arg, ``underscore_numbers`` is only available in Python versions
+    3.10 and up, so there is a test here to add it when that is the case.
     """
     defaults = [
         ('indent', 2),
@@ -170,8 +173,11 @@ def prettystr(*args, **kwargs) -> str:
         ('depth', None),
         ('compact', False),
         ('sort_dicts', False),
-        ('underscore_numbers', False),
     ]
+    vinfo = python_version()
+    if vinfo[0] == 3 and vinfo[1] >= 10:
+        # underscore_numbers only works in 3.10 and up
+        defaults.append(('underscore_numbers', False))
     kw = {}
     for tup in defaults:
         key, default = tup
@@ -223,6 +229,14 @@ def process_preset(
         # We now make the parent path part of the sys.path.
         sys.path.insert(0, parent)  # This should persist beyond this module
     return modpath, tmpdir
+
+
+def python_version() -> t.Tuple:
+    """
+    Return running Python version tuple, e.g. 3.12.2 would be (3, 12, 2)
+    """
+    _ = sys.version_info
+    return (_[0], _[1], _[2])
 
 
 def raise_on_none(**kwargs):

--- a/src/es_testbed/presets/searchable_test/definitions.py
+++ b/src/es_testbed/presets/searchable_test/definitions.py
@@ -25,6 +25,7 @@ def get_plan(scenario: str = None) -> dict:
     retval.update(buildlist())
     if not scenario:
         return retval
+    retval['uniq'] = f'scenario-{scenario}'
     newvals = getattr(scenarios, scenario)
     ilm = {}
     if 'ilm' in newvals:


### PR DESCRIPTION
* docker_test/VERSION: Update to version 1.1.0
* pyproject.toml: Switch `tool.hatch.envs.all.matrix` to `tool.hatch.envs.test.matrix` so that `hatch run test:test` will test against all supplied python versions
* pytest.ini: Disable CLI logging. We only need this for heavy debugging
* __init__.py: Bump version to 0.8.3
* es_testbed/defaults.py: Python versions < 3.10 cannnot use the newer, more explicit `TypeAlias` class, so we switched to the older type alias assignment style. This is heavily documented inline.
* es_testbed/helpers/utils.py:
  * Function prettystr: `pprint.pformat` does not have kwarg `underscore_numbers` in Python versions < 3.10, so a code workaround was added.
  * Function python_version: Return the Python version as a tuple. Could be redundant as `sys.version_info` does as well, but this allows for re-use outside without having to `import sys` again.
* es_testbed/presets/searchable_test/definitions.py: Assignss `plan.uniq` to be `f'scenario-{scenario}'`