### PR TITLE
Release prep for 0.8.4

### DIFF
--- a/docker_test/VERSION
+++ b/docker_test/VERSION
@@ -1,4 +1,4 @@
-Version: 1.1.0
-Released: 24 August 2024
+Version: 1.2.0
+Released: 30 August 2024
 
 # License and Changelog at https://github.com/untergeek/es-docker-test-scripts

--- a/docker_test/common.bash
+++ b/docker_test/common.bash
@@ -16,6 +16,9 @@ REPONAME=testing
 LIMIT=30  # How many seconds to wait to obtain the credentials
 IMAGE=docker.elastic.co/elasticsearch/elasticsearch
 MEMORY=1GB  # The heap will be half of this
+JAVA_OPTS="-Xms512m -Xmx512m"
+CLUSTER_NAME="docker_test"
+DISCOVERY_TYPE="single-node"
 
 
 #############################
@@ -25,6 +28,34 @@ MEMORY=1GB  # The heap will be half of this
 docker_logline () {
   # Return the line number that contains "${1}"
   echo $(docker logs ${NAME} | grep -n "${1}" | awk -F\: '{print $1}')
+}
+
+initial_value () {
+  # $1 is the value representation
+  local searchstr=''
+
+  case ${1} in
+    
+    'password') 
+      searchstr='elasticsearch-reset-password'
+      ;;
+
+    'nodetoken') 
+      searchstr='\--enrollment-token'
+      ;;
+
+  esac
+
+  local linenum=$(docker_logline ${searchstr})
+
+  # Increment the linenum (because we want the next line)
+  ((++linenum))
+
+  # Get the (next) line, i.e. incremented and tailed to isolate
+  retval=$(docker logs ${NAME} | head -n ${linenum} | tail -1 | awk '{print $1}')
+
+  # Strip the ANSI color/bold here. External function because of the control-M sequence
+  ansi_clean "${retval}"
 }
 
 get_espw () {
@@ -74,14 +105,8 @@ get_espw () {
     exit 1
   fi
   
-  # Increment the linenum (because we want the next line)
-  ((++linenum))
-
-  # Get the (next) line, i.e. incremented and tailed to isolate
-  retval=$(docker logs ${NAME} | head -n ${linenum} | tail -1 | awk '{print $1}')
-
-  # Strip the ANSI color/bold here. External function because of the control-M sequence
-  ESPWD=$(ansi_clean "${retval}")
+  ESPWD=$(initial_value 'password')
+  NODETOKEN=$(initial_value 'nodetoken')
 }
 
 change_espw () {
@@ -127,11 +152,9 @@ change_espw () {
 
 xpack_fork () {
 
-  echo
-  echo "Getting Elasticsearch credentials from container \"${NAME}\"..."
-  echo
+  echo "Getting Elasticsearch credentials from container ${NAME}..."
 
-  # Get the password from the change_espw function. It sets ESPWD
+  # Get the password from the get_espw function. It sets ESPWD
   get_espw 
 
   # If we have an empty value, that's a problem
@@ -143,6 +166,7 @@ xpack_fork () {
   # Put envvars in ${ENVCFG}
   echo "export ESCLIENT_USERNAME=${ESUSR}" >> ${ENVCFG}
   echo "export TEST_USER=${ESUSR}" >> ${ENVCFG}
+
   # We escape the quotes so we can include them in case of special characters
   echo "export ESCLIENT_PASSWORD=\"${ESPWD}\"" >> ${ENVCFG}
   echo "export TEST_PASS=\"${ESPWD}\"" >> ${ENVCFG}
@@ -156,7 +180,7 @@ xpack_fork () {
   echo "--cacert ${CACRT}" >> ${CURLCFG}
 
   # Complete
-  echo "Credentials captured!"
+  # echo "Credentials captured!"
 }
 
 # Save original execution path
@@ -206,11 +230,9 @@ CACRT=${PROJECT_ROOT}/http_ca.crt
 
 # Set the .env file
 ENVCFG=${PROJECT_ROOT}/${ENVFILE}
-rm -rf ${ENVCFG}
 
 # Set the curl config file and ensure we're not reusing an old one
 CURLCFG=${SCRIPTPATH}/${CURLFILE}
-rm -rf ${CURLCFG}
 
 # Determine local IPs
 OS=$(uname -a | awk '{print $1}')
@@ -229,8 +251,14 @@ fi
 ### Set Docker vars ###
 #######################
 
+# Set the TRUNK
+TRUNK=${PROJECT_NAME}-test
+
+# Set the Docker container number
+NUM=0
+
 # Set the Docker container name
-NAME=${PROJECT_NAME}-test
+NAME=${TRUNK}-${NUM}
 
 # Set the bind mount path for the snapshot repository
 REPOLOCAL=${SCRIPTPATH}/repo
@@ -238,6 +266,98 @@ REPOLOCAL=${SCRIPTPATH}/repo
 # Navigate back to the script path
 cd ${SCRIPTPATH}
 
-###################
+############################
+### URL CHECKER FUNCTION ###
+############################
+
+check_url () {
+
+  # URL = $1
+  # EXPECTED = $2
+
+  if [ "x${EXPECTED}" == "x" ]; then
+    local EXPECTED=200
+  else
+    local EXPECTED=${2}
+  fi
+
+  # Start with an empty value
+  local ACTUAL=0
+
+  # Initialize loop counter
+  local COUNTER=0
+
+  # Loop until we get our 200 code
+  while [ "${ACTUAL}" != "${EXPECTED}" ] && [ ${COUNTER} -lt ${LIMIT} ]; do
+
+    # Get our actual response
+    ACTUAL=$(curl -K ${CURLCFG} ${1})
+
+    # If we got what we expected, we're great!
+    if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+      # Sleep and try again
+      sleep 1
+      ((++COUNTER))
+    fi
+
+  done
+  # End while loop
+
+  # If we still don't have what we expected, we hit the LIMIT
+  if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+
+    echo "Unable to connect to ${1} in ${LIMIT} seconds. Unable to continue. Exiting..."
+    exit 1
+  fi
+
+  echo ${ACTUAL}
+}
+
+################################
+### Start a Docker container ###
+################################
+
+start_container () {
+  # $1 node_number
+  # $2 enrollment_token
+  # $3 node roles
+
+  if [ "x${2}" == "x" ]; then
+    local token=''
+  else
+    local token=${2}
+  fi
+
+  if [ "x${3}" == "x" ]; then
+    local roles="'data', 'data_cold', 'data_content', 'data_hot', 'data_warm', 'ingest', 'master'"
+  else
+    local roles="${3}"
+  fi
+
+  local fromzero=$(( ${1} - 1 ))
+  local nodename="${TRUNK}-${fromzero}"
+  local portnum=$(( 9200 + ${fromzero} ))
+
+echo -en "Container ID: "
+docker run -q -d -it \
+  --name ${nodename} \
+  --network ${TRUNK}-net \
+  -m ${MEMORY} \
+  -p ${portnum}:${DOCKER_PORT} \
+  -v ${REPOLOCAL}:${REPODOCKER} \
+  -e ENROLLMENT_TOKEN="${token}" \
+  -e ES_JAVA_OPTS="${JAVA_OPTS}" \
+  -e "discovery.type=${DISCOVERY_TYPE}" \
+  -e "cluster.name=${CLUSTER_NAME}" \
+  -e "node.name=node-${fromzero}" \
+  -e "node.roles=[${roles}]" \
+  -e "xpack.searchable.snapshot.shared_cache.size=100MB" \
+  -e "xpack.monitoring.templates.enabled=false" \
+  -e "path.repo=${REPODOCKER}" \
+${IMAGE}:${VERSION}
+
+}
+
+##################
 ### END COMMON ###
-###################
+##################

--- a/docker_test/destroy.sh
+++ b/docker_test/destroy.sh
@@ -1,24 +1,39 @@
 #!/bin/bash
 
+if [ "x${1}" != "verbose" ]; then
+  DEBUG=0
+else
+  DEBUG=1
+fi
+
 # Source the common.bash file from the same path as the script
 source $(dirname "$0")/common.bash
 
-echo
+log_out () {
+  # $1 is the log line
+  if [ ${DEBUG} -eq 1 ]; then
+    echo ${1}
+  fi
+}
 
-# Stop and remove the docker container
-RUNNING=$(docker ps -f name=${NAME} | grep -v NAMES | awk '{print $NF}')
-EXISTS=$(docker ps -af name=${NAME} | grep -v NAMES | awk '{print $NF}')
-if [ "${RUNNING}" == "${NAME}" ]; then
-  echo "Stopping container ${NAME}..."
-  echo "$(docker stop ${NAME}) stopped."
-fi
-if [ "${EXISTS}" == "${NAME}" ]; then
-  echo "Removing container ${NAME}..."
-  echo "$(docker rm -f ${NAME}) deleted."
-fi
+# Stop running containers
+echo "Stopping all containers..."
+RUNNING=$(docker ps | grep -v NAMES | grep ${TRUNK} | awk '{print $NF}')
+for container in ${RUNNING}; do
+  log_out "Stopping container ${container}..."
+  log_out "$(docker stop ${container}) stopped."
+done
+
+# Remove existing containers
+echo "Removing all containers..."
+EXISTS=$(docker ps -a | grep -v NAMES | grep ${TRUNK} | awk '{print $NF}')
+for container in ${EXISTS}; do
+  log_out "Removing container ${container}..."
+  log_out "$(docker rm -f ${container}) deleted."
+done
 
 # Delete Docker network
-docker network rm -f ${NAME}-net > /dev/null 2>&1
+docker network rm -f ${TRUNK}-net > /dev/null 2>&1
 
 # Delete .env file and curl config file
 echo "Deleting remaining files and directories"

--- a/docker_test/scenarios.bash
+++ b/docker_test/scenarios.bash
@@ -1,0 +1,18 @@
+# Docker environment setup scenarios
+
+case ${2} in
+
+  'frozen_node')
+    NODECOUNT=2
+    DISCOVERY_TYPE="multi-node"
+    ROLES="data_frozen"
+    ;;
+
+  *)
+    echo "Error! SCENARIO not recognized."
+    echo "USAGE: ${0} VERSION [SCENARIO]"
+    echo "You entered: ${2}"
+    exit 1
+    ;;
+
+esac

--- a/src/es_testbed/__init__.py
+++ b/src/es_testbed/__init__.py
@@ -1,6 +1,6 @@
 """Make classes easier to import here"""
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 from es_testbed._base import TestBed
 from es_testbed._plan import PlanBuilder

--- a/src/es_testbed/_base.py
+++ b/src/es_testbed/_base.py
@@ -205,6 +205,7 @@ class TestBed:
         Setup each EntityMgr child class
         """
         kw = {'client': self.client, 'plan': self.plan}
+
         self.ilmmgr = IlmMgr(**kw)
         self.ilmmgr.setup()
         self.componentmgr = ComponentMgr(**kw)

--- a/src/es_testbed/presets/searchable_test/definitions.py
+++ b/src/es_testbed/presets/searchable_test/definitions.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from json import loads
 from es_client.helpers.utils import get_yaml
-from . import scenarios
+from .scenarios import Scenarios
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ def get_plan(scenario: str = None) -> dict:
     if not scenario:
         return retval
     retval['uniq'] = f'scenario-{scenario}'
+    scenarios = Scenarios()
     newvals = getattr(scenarios, scenario)
     ilm = {}
     if 'ilm' in newvals:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -50,10 +50,7 @@ class TestAny:
     def tb(self, client, prefix, uniq, skip_no_repo):  # skip_localhost fixed?
         """TestBed setup/teardown"""
         skip_no_repo(get_sstier(self.scenario) in ['cold', 'frozen'])
-        # skip_localhost(bool(self.scenario in ['frozen_ilm', 'frozen_ds']))
-        # 8.15.0 seems to work okay for the Docker-based cold & frozen tests.
         teebee = TestBed(client, builtin='searchable_test', scenario=self.scenario)
-        # Update plan settings for testing
         teebee.settings['prefix'] = prefix
         teebee.settings['uniq'] = uniq
         teebee.setup()


### PR DESCRIPTION
Most of this change is in the form of using es-docker-test-scripts version 1.2.0

The 1.2.0 version of the `docker_test` scripts proved necessary to run two docker containers as part of a single cluster, with one of them being a `data_frozen` node.

This is accomplished by running:

```
docker_test/create.sh 8.15.0 frozen_node
```

where `frozen_node` is the scenario defined in the docker_test scripts for deploying a 2 node cluster with one `data_frozen` node.

With that out of the way, the other changes were to the searchable_test preset scenario.

The import of this scenario seemed to require class attributes for the desired settings to be properly exposed, so `scenarios.py` was changed to include a class `Scenarios`, with every possible scenario as a class `@property`/attribute.

Testing showed that these values properly propagated.

Now, with both changes in place, the prior failure to get cold and frozen ILM tests to work is a thing of the past.