### PR TITLE
Tearing off the band-aid: Double-quote strings preferred

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,21 +1,16 @@
-# .readthedocs.yaml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
+---
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-22.04"
   tools:
     python: "3.12"
-
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-   configuration: docs/conf.py
 
 python:
   install:
     - method: pip
       path: .
+    - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'hatchling.build'
 
 [project]
 name = 'es-testbed'
-authors = [{ name='Elastic', email='info@elastic.co' }]
+authors = [{ name='Aaron Mildenstein', email='aaron@mildensteins.com' }]
 dynamic = ['version']
 description = 'Library to help with building and tearing down indices, data streams, repositories and snapshots'
 license = { text='Apache-2.0' }
@@ -33,9 +33,9 @@ keywords = [
 dependencies = [
     'gitpython==3.1.43',
     'dotmap==1.3.30',
-    'es_client>=8.18.1',
-    'es-wait>=0.15.0',
-    'tiered_debug==1.2.1',
+    'es_client>=8.18.2',
+    'es-wait>=0.15.1',
+    'tiered_debug==1.3.0',
 ]
 
 [project.optional-dependencies]
@@ -46,7 +46,7 @@ test = [
     'pytest-cov',
     'pytest-dotenv',
 ]
-doc = ['sphinx', 'sphinx_rtd_theme']
+doc = ['furo>=2024.8.6']
 
 [tool.hatch.module]
 name = 'es-testbed'
@@ -108,7 +108,7 @@ all = [
 [tool.black]
 target-version = ['py38']
 line-length = 88
-skip-string-normalization = true
+skip-string-normalization = false
 include = '\.pyi?$'
 
 [tool.coverage.run]

--- a/src/es_testbed/__init__.py
+++ b/src/es_testbed/__init__.py
@@ -1,9 +1,59 @@
-"""Make classes easier to import here"""
+"""ES Testbed: A Python library for generating Elasticsearch test scenarios."""
 
-__version__ = '0.11.2'
-
+from datetime import datetime
 from es_testbed._base import TestBed
 from es_testbed._plan import PlanBuilder
 from es_testbed.debug import debug
 
-__all__ = ['TestBed', 'PlanBuilder', 'debug']
+__version__ = "0.11.2"
+
+FIRST_YEAR = 2025
+now = datetime.now()
+if now.year == FIRST_YEAR:
+    COPYRIGHT_YEARS = "2025"
+else:
+    COPYRIGHT_YEARS = f"2025-{now.year}"
+
+__author__ = "Aaron Mildenstein"
+__copyright__ = f"{COPYRIGHT_YEARS}, {__author__}"
+__license__ = "Apache 2.0"
+__status__ = "Development"
+__description__ = (
+    "Library to help with building and tearing down indices, data streams, "
+    "repositories and snapshots, and other test scenarios in Elasticsearch."
+)
+__url__ = "https://github.com/untergeek/es-testbed"
+__email__ = "aaron@mildensteins.com"
+__maintainer__ = "Aaron Mildenstein"
+__maintainer_email__ = f"{__email__}"
+__keywords__ = [
+    "elasticsearch",
+    "index",
+    "testing",
+    "datastream",
+    "repository",
+    "snapshot",
+]
+__classifiers__ = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+
+__all__ = [
+    "TestBed",
+    "PlanBuilder",
+    "debug",
+    "__author__",
+    "__copyright__",
+    "__version__",
+]

--- a/src/es_testbed/_plan.py
+++ b/src/es_testbed/_plan.py
@@ -97,17 +97,17 @@ class PlanBuilder:
         Raises:
             ValueError: Must provide a settings dictionary
         """
-        debug.lv2('Initializing PlanBuilder object...')
+        debug.lv2("Initializing PlanBuilder object...")
         if settings is None:
-            raise ValueError('Must provide a settings dictionary')
+            raise ValueError("Must provide a settings dictionary")
         self.settings = settings
-        debug.lv5(f'SETTINGS: {settings}')
+        debug.lv5(f"SETTINGS: {settings}")
         self._plan = DotMap(TESTPLAN)
-        debug.lv5(f'INITIAL PLAN: {prettystr(self._plan)}')
-        self._plan.cleanup = 'UNSET'  # Future use?
+        debug.lv5(f"INITIAL PLAN: {prettystr(self._plan)}")
+        self._plan.cleanup = "UNSET"  # Future use?
         if autobuild:
             self.setup()
-        debug.lv3('PlanBuilder object initialized')
+        debug.lv3("PlanBuilder object initialized")
 
     @property
     def plan(self) -> DotMap:
@@ -117,12 +117,12 @@ class PlanBuilder:
     @begin_end()
     def _create_lists(self) -> None:
         names = [
-            'indices',
-            'data_stream',
-            'snapshots',
-            'ilm_policies',
-            'index_templates',
-            'component_templates',
+            "indices",
+            "data_stream",
+            "snapshots",
+            "ilm_policies",
+            "index_templates",
+            "component_templates",
         ]
         for name in names:
             self._plan[name] = []
@@ -134,28 +134,28 @@ class PlanBuilder:
         self._create_lists()
         self.update(self.settings)  # Override with settings.
         self.update_rollover_alias()
-        debug.lv3('Rollover alias updated')
+        debug.lv3("Rollover alias updated")
         self.update_ilm()
-        debug.lv5(f'FINAL PLAN: {prettystr(self._plan.toDict())}')
+        debug.lv5(f"FINAL PLAN: {prettystr(self._plan.toDict())}")
 
     @begin_end()
     def update(self, settings: t.Dict) -> None:
         """Update the Plan DotMap"""
         self._plan.update(DotMap(settings))
-        debug.lv5(f'Updated plan: {prettystr(self._plan.toDict())}')
+        debug.lv5(f"Updated plan: {prettystr(self._plan.toDict())}")
 
     @begin_end()
     def update_ilm(self) -> None:
         """Update the ILM portion of the Plan DotMap"""
         setdefault = False
-        if 'ilm' not in self._plan:
+        if "ilm" not in self._plan:
             debug.lv3('key "ilm" is not in plan')
             setdefault = True
         if isinstance(self._plan.ilm, dict):
             _ = DotMap(self._plan.ilm)
             self._plan.ilm = _
         if isinstance(self._plan.ilm, DotMap):
-            if 'enabled' not in self._plan.ilm:
+            if "enabled" not in self._plan.ilm:
                 # Override with defaults
                 debug.lv3(
                     'plan.ilm does not have key "enabled". Overriding with defaults'
@@ -166,37 +166,37 @@ class PlanBuilder:
                 logger.warning(
                     '"plan.ilm: True" is incorrect. Use plan.ilm.enabled: True'
                 )
-            debug.lv3('plan.ilm is boolean. Overriding with defaults')
+            debug.lv3("plan.ilm is boolean. Overriding with defaults")
             setdefault = True
         if setdefault:
-            debug.lv3('Setting defaults for ILM')
-            self._plan.ilm = DotMap(TESTPLAN['ilm'])
+            debug.lv3("Setting defaults for ILM")
+            self._plan.ilm = DotMap(TESTPLAN["ilm"])
         if self._plan.ilm.enabled:
             ilm = self._plan.ilm
             if not isinstance(self._plan.ilm.phases, list):
-                logger.error('Phases is not a list!')
-                self._plan.ilm.phases = TESTPLAN['ilm']['phases']
+                logger.error("Phases is not a list!")
+                self._plan.ilm.phases = TESTPLAN["ilm"]["phases"]
             for entity in self._plan.index_buildlist:
-                if 'searchable' in entity and entity['searchable'] is not None:
-                    if not entity['searchable'] in ilm.phases:
-                        ilm.phases.append(entity['searchable'])
-            debug.lv5(f'ILM = {ilm}')
-            debug.lv5(f'self._plan.ilm = {self._plan.ilm}')
+                if "searchable" in entity and entity["searchable"] is not None:
+                    if not entity["searchable"] in ilm.phases:
+                        ilm.phases.append(entity["searchable"])
+            debug.lv5(f"ILM = {ilm}")
+            debug.lv5(f"self._plan.ilm = {self._plan.ilm}")
             kwargs = {
-                'phases': ilm.phases,
-                'forcemerge': ilm.forcemerge,
-                'max_num_segments': ilm.max_num_segments,
-                'readonly': ilm.readonly,
-                'repository': self._plan.repository,
+                "phases": ilm.phases,
+                "forcemerge": ilm.forcemerge,
+                "max_num_segments": ilm.max_num_segments,
+                "readonly": ilm.readonly,
+                "repository": self._plan.repository,
             }
-            debug.lv5(f'KWARGS = {kwargs}')
+            debug.lv5(f"KWARGS = {kwargs}")
             self._plan.ilm.policy = build_ilm_policy(**kwargs)
 
     @begin_end()
     def update_rollover_alias(self) -> None:
         """Update the Rollover Alias value"""
         if self._plan.rollover_alias:
-            self._plan.rollover_alias = f'{self._plan.prefix}-idx-{self._plan.uniq}'
+            self._plan.rollover_alias = f"{self._plan.prefix}-idx-{self._plan.uniq}"
         else:
             self._plan.rollover_alias = None
-        debug.lv5(f'Updated rollover_alias = {self._plan.rollover_alias}')
+        debug.lv5(f"Updated rollover_alias = {self._plan.rollover_alias}")

--- a/src/es_testbed/debug.py
+++ b/src/es_testbed/debug.py
@@ -1,86 +1,89 @@
 """Module for tiered debugging with a global TieredDebug instance.
 
-This module defines a global `debug` instance of `TieredDebug` and a `begin_end`
-decorator to log function call boundaries at specified debug levels. Copy this
-file into your project to enable project-wide debugging. Import `debug` and `begin_end`
-in any module with `from .debug import debug, begin_end`.
+Provides a global `TieredDebug` instance and a `begin_end` decorator to
+log function entry and exit at specified debug levels. Designed for use
+in projects like ElasticKeeper and ElasticCheckpoint to trace function
+execution with configurable stack levels.
+
+Examples:
+    >>> from tiered_debug.debug import debug, begin_end
+    >>> debug.level = 3
+    >>> import logging
+    >>> debug.add_handler(logging.StreamHandler())
+    >>> @begin_end(debug, begin=2, end=3, stacklevel=2, extra={"func": "test"})
+    ... def example():
+    ...     return "Test"
+    >>> example()
+    'Test'
 """
 
-import typing as t
 from functools import wraps
-from tiered_debug import TieredDebug, DebugLevel
+from typing import Any, Dict, Optional
 
-DEFAULT_BEGIN: DebugLevel = 2
-"""Default debug level for begin message in begin_end decorator."""
+from tiered_debug import TieredDebug
 
-DEFAULT_END: DebugLevel = 3
-"""Default debug level for end message in begin_end decorator."""
+DEFAULT_BEGIN = 2
+"""Default debug level for BEGIN messages."""
 
-debug = TieredDebug()
-"""Global TieredDebug instance for project-wide debugging."""
+DEFAULT_END = 3
+"""Default debug level for END messages."""
+
+debug = TieredDebug(level=1, stacklevel=3)
+"""Global TieredDebug instance with default level 1 and stacklevel 3."""
 
 
 def begin_end(
-    begin: t.Optional[DebugLevel] = DEFAULT_BEGIN,
-    end: t.Optional[DebugLevel] = DEFAULT_END,
-    debug_obj: t.Optional[TieredDebug] = None,
-    stklvl: t.Optional[int] = None,
-) -> t.Callable:
-    """Decorator to log the beginning and end of a function call.
+    debug_obj: Optional[TieredDebug] = None,
+    begin: int = DEFAULT_BEGIN,
+    end: int = DEFAULT_END,
+    stacklevel: int = 2,
+    extra: Optional[Dict[str, Any]] = None,
+):
+    """Decorator to log function entry and exit at specified debug levels.
 
-    Logs the start and end of a function at the specified debug levels using the
-    provided or global `debug` instance. If `begin` or `end` is invalid (not 1-5),
-    logs an error and uses default levels (2 for begin, 3 for end). The stack level
-    defaults to one level beyond the global `debug.stacklevel` to report the caller's
-    context.
+    Logs "BEGIN CALL" at the `begin` level and "END CALL" at the `end`
+    level using the provided or global debug instance. Adjusts the
+    stacklevel by 1 to report the correct caller.
 
-    :param begin: Debug level (1-5) for the begin message. Defaults to 2.
-    :type begin: Optional[DebugLevel]
-    :param end: Debug level (1-5) for the end message. Defaults to 3.
-    :type end: Optional[DebugLevel]
-    :param debug_obj: TieredDebug instance to use for logging. Defaults to global
-        `debug`.
-    :type debug_obj: Optional[TieredDebug]
-    :param stklvl: Stack level for caller reporting. Defaults to debug.stacklevel + 1.
-    :type stklvl: Optional[int]
-    :return: Decorated function.
-    :rtype: Callable
+    Args:
+        debug_obj: TieredDebug instance to use (default: global debug).
+        begin: Debug level for BEGIN message (1-5, default 2). (int)
+        end: Debug level for END message (1-5, default 3). (int)
+        stacklevel: Stack level for reporting (1-9, default 2). (int)
+        extra: Extra metadata dictionary (default None). (Dict[str, Any])
+
+    Returns:
+        Callable: Decorated function with logging.
+
+    Examples:
+        >>> debug.level = 3
+        >>> import logging
+        >>> debug.add_handler(logging.StreamHandler())
+        >>> @begin_end(debug, begin=2, end=3)
+        ... def test_func():
+        ...     return "Result"
+        >>> test_func()
+        'Result'
     """
-    if debug_obj is None:
-        debug_obj = globals()["debug"]
+    debug_instance = debug_obj if debug_obj is not None else debug
 
-    effective_begin = begin
-    effective_end = end
-
-    if begin not in (1, 2, 3, 4, 5):
-        debug_obj.logger.error(
-            f"Invalid begin level: {begin}. Using default: {DEFAULT_BEGIN}"
-        )
-        effective_begin = DEFAULT_BEGIN
-    if end not in (1, 2, 3, 4, 5):
-        debug_obj.logger.error(
-            f"Invalid end level: {end}. Using default: {DEFAULT_END}"
-        )
-        effective_end = DEFAULT_END
-
-    mmap = {
-        1: debug_obj.lv1,
-        2: debug_obj.lv2,
-        3: debug_obj.lv3,
-        4: debug_obj.lv4,
-        5: debug_obj.lv5,
-    }
-
-    def decorator(func: t.Callable) -> t.Callable:
+    def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            common = f"CALL: {func.__name__}()"
-            effective_stklvl = (
-                stklvl if stklvl is not None else debug_obj.stacklevel + 1
+            effective_stacklevel = stacklevel + 1
+            debug_instance.log(
+                begin,
+                f"BEGIN CALL: {func.__name__}()",
+                stacklevel=effective_stacklevel,
+                extra=extra,
             )
-            mmap[effective_begin](f"BEGIN {common}", stklvl=effective_stklvl)
             result = func(*args, **kwargs)
-            mmap[effective_end](f"END {common}", stklvl=effective_stklvl)
+            debug_instance.log(
+                end,
+                f"END CALL: {func.__name__}()",
+                stacklevel=effective_stacklevel,
+                extra=extra,
+            )
             return result
 
         return wrapper

--- a/src/es_testbed/defaults.py
+++ b/src/es_testbed/defaults.py
@@ -2,78 +2,78 @@
 
 import typing as t
 
-EPILOG: str = 'Learn more at https://github.com/untergeek/es-testbed'
+EPILOG: str = "Learn more at https://github.com/untergeek/es-testbed"
 """Epilog for the Click CLI"""
 
-HELP_OPTIONS: dict = {'help_option_names': ['-h', '--help']}
+HELP_OPTIONS: dict = {"help_option_names": ["-h", "--help"]}
 """Default help options for Click commands"""
 
-COLD_PREFIX: str = 'restored-'
+COLD_PREFIX: str = "restored-"
 """Prefix for cold searchable snapshot indices"""
 
-FROZEN_PREFIX: str = 'partial-'
+FROZEN_PREFIX: str = "partial-"
 """Prefix for frozen searchable snapshot indices"""
 
-SS_PREFIX: t.Dict[str, str] = {'cold': COLD_PREFIX, 'frozen': FROZEN_PREFIX}
+SS_PREFIX: t.Dict[str, str] = {"cold": COLD_PREFIX, "frozen": FROZEN_PREFIX}
 """Dictionary of prefixes for searchable snapshot indices"""
 
 NAMEMAPPER: t.Dict[str, str] = {
-    'index': 'idx',
-    'indices': 'idx',  # This is to aid testing and other places where kind is indices
-    'data_stream': 'ds',
-    'component': 'cmp',
-    'ilm': 'ilm',
-    'template': 'tmpl',
-    'snapshot': 'snp',
+    "index": "idx",
+    "indices": "idx",  # This is to aid testing and other places where kind is indices
+    "data_stream": "ds",
+    "component": "cmp",
+    "ilm": "ilm",
+    "template": "tmpl",
+    "snapshot": "snp",
 }
 """Mapping of names to abbreviations for use in the CLI"""
 
-PAUSE_DEFAULT: str = '1.0'
+PAUSE_DEFAULT: str = "1.0"
 """Default value for the pause time in seconds"""
-PAUSE_ENVVAR: str = 'ES_TESTBED_PAUSE'
+PAUSE_ENVVAR: str = "ES_TESTBED_PAUSE"
 """Environment variable for the pause time"""
 
 PLURALMAP: t.Dict[str, str] = {
-    'ilm': 'ILM Policies',
-    'index': 'indices',
+    "ilm": "ILM Policies",
+    "index": "indices",
 }
 """Mapping of singular to plural names for use in the CLI"""
 
 TESTPLAN: dict = {
-    'type': 'indices',
-    'prefix': 'es-testbed',
-    'repository': None,
-    'rollover_alias': None,
-    'ilm': {
-        'enabled': False,
-        'phases': ['hot', 'delete'],
-        'readonly': None,
-        'forcemerge': False,
-        'max_num_segments': 1,
+    "type": "indices",
+    "prefix": "es-testbed",
+    "repository": None,
+    "rollover_alias": None,
+    "ilm": {
+        "enabled": False,
+        "phases": ["hot", "delete"],
+        "readonly": None,
+        "forcemerge": False,
+        "max_num_segments": 1,
     },
-    'entities': [],
+    "entities": [],
 }
 """Default values for the TestPlan settings"""
 
 TIER: dict = {
-    'hot': {'pref': 'data_hot,data_content'},
-    'warm': {'pref': 'data_warm,data_hot,data_content'},
-    'cold': {
-        'pref': 'data_cold,data_warm,data_hot,data_content',
-        'prefix': 'restored',
-        'storage': 'full_copy',
+    "hot": {"pref": "data_hot,data_content"},
+    "warm": {"pref": "data_warm,data_hot,data_content"},
+    "cold": {
+        "pref": "data_cold,data_warm,data_hot,data_content",
+        "prefix": "restored",
+        "storage": "full_copy",
     },
-    'frozen': {
-        'pref': 'data_frozen',
-        'prefix': 'partial',
-        'storage': 'shared_cache',
+    "frozen": {
+        "pref": "data_frozen",
+        "prefix": "partial",
+        "storage": "shared_cache",
     },
 }
 """Default values for the ILM tiers"""
 
-TIMEOUT_DEFAULT: str = '30'
+TIMEOUT_DEFAULT: str = "30"
 """Default timeout for the testbed in seconds"""
-TIMEOUT_ENVVAR: str = 'ES_TESTBED_TIMEOUT'
+TIMEOUT_ENVVAR: str = "ES_TESTBED_TIMEOUT"
 """Environment variable for the testbed timeout"""
 
 # Define IlmPhase as a typing alias to be reused multiple times
@@ -97,41 +97,41 @@ IlmPhase = t.Dict[
 
 def ilmhot() -> IlmPhase:
     """Return a default hot ILM phase"""
-    return {'actions': {'rollover': {'max_primary_shard_size': '1gb', 'max_age': '1d'}}}
+    return {"actions": {"rollover": {"max_primary_shard_size": "1gb", "max_age": "1d"}}}
 
 
 def ilmwarm() -> IlmPhase:
     """Return a default warm ILM phase"""
-    return {'min_age': '2d', 'actions': {}}
+    return {"min_age": "2d", "actions": {}}
 
 
 def ilmcold() -> IlmPhase:
     """Return a default cold ILM phase"""
-    return {'min_age': '3d', 'actions': {}}
+    return {"min_age": "3d", "actions": {}}
 
 
 def ilmfrozen() -> IlmPhase:
     """Return a default frozen ILM phase"""
-    return {'min_age': '4d', 'actions': {}}
+    return {"min_age": "4d", "actions": {}}
 
 
 def ilmdelete() -> IlmPhase:
     """Return a default delete ILM phase"""
-    return {'min_age': '5d', 'actions': {'delete': {}}}
+    return {"min_age": "5d", "actions": {"delete": {}}}
 
 
 def ilm_phase(value: str) -> IlmPhase:
     """Return the default phase step based on 'value'"""
     phase_map = {
-        'hot': ilmhot(),
-        'warm': ilmwarm(),
-        'cold': ilmcold(),
-        'frozen': ilmfrozen(),
-        'delete': ilmdelete(),
+        "hot": ilmhot(),
+        "warm": ilmwarm(),
+        "cold": ilmcold(),
+        "frozen": ilmfrozen(),
+        "delete": ilmdelete(),
     }
     return {value: phase_map[value]}
 
 
 def ilm_force_merge(max_num_segments: int = 1) -> t.Dict[str, t.Dict[str, int]]:
     """Return an ILM policy force merge action block using max_num_segments"""
-    return {'forcemerge': {'max_num_segments': max_num_segments}}
+    return {"forcemerge": {"max_num_segments": max_num_segments}}

--- a/src/es_testbed/entities/__init__.py
+++ b/src/es_testbed/entities/__init__.py
@@ -4,4 +4,4 @@ from es_testbed.entities.alias import Alias
 from es_testbed.entities.index import Index
 from es_testbed.entities.data_stream import DataStream
 
-__all__ = ['Alias', 'Index', 'DataStream']
+__all__ = ["Alias", "Index", "DataStream"]

--- a/src/es_testbed/entities/alias.py
+++ b/src/es_testbed/entities/alias.py
@@ -18,12 +18,12 @@ class Alias(Entity):
 
     def __init__(
         self,
-        client: 'Elasticsearch',
+        client: "Elasticsearch",
         name: t.Union[str, None] = None,
     ):
-        debug.lv2('Initializing Alias entity object...')
+        debug.lv2("Initializing Alias entity object...")
         super().__init__(client=client, name=name)
-        debug.lv3('Alias entity object initialized')
+        debug.lv3("Alias entity object initialized")
 
     @begin_end()
     def rollover(self) -> None:
@@ -34,18 +34,18 @@ class Alias(Entity):
     def verify(self, index_list: t.Sequence[str]) -> bool:
         retval = False
         res = resolver(self.client, self.name)
-        debug.lv5(f'resolver response: {prettystr(res)}')
-        for idx, alias in enumerate(res['aliases']):
-            if alias['name'] == self.name:
+        debug.lv5(f"resolver response: {prettystr(res)}")
+        for idx, alias in enumerate(res["aliases"]):
+            if alias["name"] == self.name:
                 debug.lv3(
-                    f'Confirm list index position [{idx}] match of alias '
-                    f'{prettystr(alias)}'
+                    f"Confirm list index position [{idx}] match of alias "
+                    f"{prettystr(alias)}"
                 )
             else:
                 continue
-            if alias['indices'] == index_list:
-                debug.lv3(f'Confirm match of indices backed by alias {self.name}')
+            if alias["indices"] == index_list:
+                debug.lv3(f"Confirm match of indices backed by alias {self.name}")
                 retval = True
                 break
-        debug.lv5(f'Return value = {retval}')
+        debug.lv5(f"Return value = {retval}")
         return retval

--- a/src/es_testbed/entities/data_stream.py
+++ b/src/es_testbed/entities/data_stream.py
@@ -18,21 +18,21 @@ class DataStream(Alias):
 
     def __init__(
         self,
-        client: 'Elasticsearch',
+        client: "Elasticsearch",
         name: t.Union[str, None] = None,
     ):
-        debug.lv2('Initializing DataStream entity object...')
+        debug.lv2("Initializing DataStream entity object...")
         super().__init__(client=client, name=name)
         self.index_tracker = []
         self.alias = None
-        debug.lv3('DataStream entity object initialized')
+        debug.lv3("DataStream entity object initialized")
 
     @property
     @begin_end()
     def backing_indices(self):
         """Return the list of backing indices for the data_stream"""
         retval = get_backing_indices(self.client, self.name)
-        debug.lv5(f'Return value = {retval}')
+        debug.lv5(f"Return value = {retval}")
         return retval
 
     @begin_end()
@@ -40,7 +40,7 @@ class DataStream(Alias):
         """Verify that the backing indices match ``index_list``"""
         retval = False
         if self.backing_indices == index_list:
-            debug.lv3(f'Confirm match of data_stream "{self.name}" backing indices')
+            debug.lv3(f"Confirm match of data_stream '{self.name}' backing indices")
             retval = True
-        debug.lv5(f'Return value = {retval}')
+        debug.lv5(f"Return value = {retval}")
         return retval

--- a/src/es_testbed/entities/entity.py
+++ b/src/es_testbed/entities/entity.py
@@ -14,7 +14,7 @@ class Entity:
 
     def __init__(
         self,
-        client: 'Elasticsearch',
+        client: "Elasticsearch",
         name: t.Union[str, None] = None,
     ):
         self.client = client
@@ -27,15 +27,15 @@ class Entity:
         Determine if self.name is the write index for either a rollover alias or a
         data_stream
         """
-        if self.name.startswith('.ds-'):  # Datastream
-            debug.lv2('Datastream detected')
-            ds = resolver(self.client, self.name)['indices'][0]['data_stream']
-            debug.lv5(f'resolver response: {ds}')
+        if self.name.startswith(".ds-"):  # Datastream
+            debug.lv2("Datastream detected")
+            ds = resolver(self.client, self.name)["indices"][0]["data_stream"]
+            debug.lv5(f"resolver response: {ds}")
             retval = bool(self.name == get_ds_current(self.client, ds))
-            debug.lv3('Exiting method, returning value')
-            debug.lv5(f'Value = {retval}')
+            debug.lv3("Exiting method, returning value")
+            debug.lv5(f"Value = {retval}")
             return retval
-        debug.lv2('Rollover alias detected')
+        debug.lv2("Rollover alias detected")
         retval = bool(self.name == find_write_index(self.client, self.name))
-        debug.lv5(f'Return value = {retval}')
+        debug.lv5(f"Return value = {retval}")
         return retval

--- a/src/es_testbed/entities/index.py
+++ b/src/es_testbed/entities/index.py
@@ -28,17 +28,17 @@ class Index(Entity):
 
     def __init__(
         self,
-        client: 'Elasticsearch',
+        client: "Elasticsearch",
         name: t.Union[str, None] = None,
         snapmgr=None,
         policy_name: str = None,
     ):
-        debug.lv2('Initializing Index entity object...')
+        debug.lv2("Initializing Index entity object...")
         super().__init__(client=client, name=name)
         self.policy_name = policy_name
         self.ilm_tracker = None
         self.snapmgr = snapmgr
-        debug.lv3('Index entity object initialized')
+        debug.lv3("Index entity object initialized")
 
     @property
     @begin_end()
@@ -46,20 +46,20 @@ class Index(Entity):
         target = None
         phases = self.ilm_tracker.policy_phases
         curr = self.ilm_tracker.explain.phase
-        if not bool(('cold' in phases) or ('frozen' in phases)):
+        if not bool(("cold" in phases) or ("frozen" in phases)):
             debug.lv3(f'ILM Policy for "{self.name}" has no cold/frozen phases')
             target = curr  # Keep the same
-        if bool(('cold' in phases) and ('frozen' in phases)):
-            if self.ilm_tracker.pname(curr) < self.ilm_tracker.pname('cold'):
-                target = 'cold'
-            elif curr == 'cold':
-                target = 'frozen'
-            elif self.ilm_tracker.pname(curr) >= self.ilm_tracker.pname('frozen'):
+        if bool(("cold" in phases) and ("frozen" in phases)):
+            if self.ilm_tracker.pname(curr) < self.ilm_tracker.pname("cold"):
+                target = "cold"
+            elif curr == "cold":
+                target = "frozen"
+            elif self.ilm_tracker.pname(curr) >= self.ilm_tracker.pname("frozen"):
                 target = curr
-        elif bool(('cold' in phases) and ('frozen' not in phases)):
-            target = 'cold'
-        elif bool(('cold' not in phases) and ('frozen' in phases)):
-            target = 'frozen'
+        elif bool(("cold" in phases) and ("frozen" not in phases)):
+            target = "cold"
+        elif bool(("cold" not in phases) and ("frozen" in phases)):
+            target = "frozen"
         return target
 
     @property
@@ -69,54 +69,54 @@ class Index(Entity):
 
     @begin_end()
     def _add_snap_step(self) -> None:
-        debug.lv4('Getting snapshot name for tracking...')
+        debug.lv4("Getting snapshot name for tracking...")
         snapname = snapshot_name(self.client, self.name)
-        debug.lv5(f'Snapshot {snapname} backs {self.name}')
+        debug.lv5(f"Snapshot {snapname} backs {self.name}")
         self.snapmgr.add_existing(snapname)
 
     @begin_end()
     def _ilm_step(self) -> None:
         """Subroutine for waiting for an ILM step to complete"""
         step = {
-            'phase': self.ilm_tracker.explain.phase,
-            'action': self.ilm_tracker.explain.action,
-            'name': self.ilm_tracker.explain.step,
+            "phase": self.ilm_tracker.explain.phase,
+            "action": self.ilm_tracker.explain.action,
+            "name": self.ilm_tracker.explain.step,
         }
-        debug.lv5(f'{self.name}: Current Step: {step}')
+        debug.lv5(f"{self.name}: Current Step: {step}")
         step = IlmStep(
             self.client, pause=PAUSE_VALUE, timeout=TIMEOUT_VALUE, name=self.name
         )
         try:
-            debug.lv4('TRY: Waiting for ILM step to complete...')
+            debug.lv4("TRY: Waiting for ILM step to complete...")
             self._wait_try(step.wait)
         except TestbedFailure as err:
             logger.error(err.message)
-            debug.lv3('Exiting method, raising exception')
-            debug.lv5(f'Exception: {prettystr(err)}')
+            debug.lv3("Exiting method, raising exception")
+            debug.lv5(f"Exception: {prettystr(err)}")
             raise err
 
     @begin_end()
     def _wait_try(self, func: t.Callable) -> None:
         """Wait for an es-wait function to complete"""
         try:
-            debug.lv4('TRY: To run func()...')
+            debug.lv4("TRY: To run func()...")
             func()
         except EsWaitFatal as wait:
             # EsWaitFatal indicates we had more than the allowed number of exceptions
-            msg = f'{wait.message}. Elapsed time: {wait.elapsed}. Errors: {wait.errors}'
-            debug.lv3('Exiting method, raising exception')
-            debug.lv5(f'Exception: {prettystr(wait)}')
+            msg = f"{wait.message}. Elapsed time: {wait.elapsed}. Errors: {wait.errors}"
+            debug.lv3("Exiting method, raising exception")
+            debug.lv5(f"Exception: {prettystr(wait)}")
             raise TestbedFailure(msg) from wait
         except EsWaitTimeout as wait:
             # EsWaitTimeout indicates we hit the timeout
-            msg = f'{wait.message}. Total elapsed time: {wait.elapsed}.'
-            debug.lv3('Exiting method, raising exception')
-            debug.lv5(f'Exception: {prettystr(wait)}')
+            msg = f"{wait.message}. Total elapsed time: {wait.elapsed}."
+            debug.lv3("Exiting method, raising exception")
+            debug.lv5(f"Exception: {prettystr(wait)}")
             raise TestbedFailure(msg) from wait
         except Exception as err:
-            debug.lv3('Exiting method, raising exception')
-            debug.lv5(f'Exception: {prettystr(err)}')
-            raise TestbedFailure(f'General Exception caught: {prettystr(err)}') from err
+            debug.lv3("Exiting method, raising exception")
+            debug.lv5(f"Exception: {prettystr(err)}")
+            raise TestbedFailure(f"General Exception caught: {prettystr(err)}") from err
 
     @begin_end()
     def _mounted_step(self, target: str) -> str:
@@ -124,30 +124,30 @@ class Index(Entity):
             debug.lv4(f'TRY: Moving "{self.name}" to ILM phase "{target}"')
             self.ilm_tracker.advance(phase=target)
         except BadRequestError as err:
-            logger.critical(f'err: {prettystr(err)}')
-            debug.lv3('Exiting method, raising exception')
-            debug.lv5(f'Exception: {prettystr(err)}')
+            logger.critical(f"err: {prettystr(err)}")
+            debug.lv3("Exiting method, raising exception")
+            debug.lv5(f"Exception: {prettystr(err)}")
             raise err  # Re-raise after logging
         # At this point, it's "in" a searchable tier, but the index name hasn't
         # changed yet
         newidx = mounted_name(self.name, target)
-        debug.lv3(f'Waiting for ILM phase change to complete. New index: {newidx}')
+        debug.lv3(f"Waiting for ILM phase change to complete. New index: {newidx}")
         wait_kwargs = {
-            'name': newidx,
-            'kind': 'index',
-            'pause': PAUSE_VALUE,
-            'timeout': TIMEOUT_VALUE,
+            "name": newidx,
+            "kind": "index",
+            "pause": PAUSE_VALUE,
+            "timeout": TIMEOUT_VALUE,
         }
 
         test = Exists(self.client, **wait_kwargs)
-        debug.lv5(f'Exists response: {prettystr(test)}')
+        debug.lv5(f"Exists response: {prettystr(test)}")
         try:
             debug.lv4(f'TRY: Waiting for "{newidx}" to exist...')
             self._wait_try(test.wait)
         except TestbedFailure as err:
             logger.error(err.message)
-            debug.lv3('Exiting method, raising exception')
-            debug.lv5(f'Exception: {prettystr(err)}')
+            debug.lv3("Exiting method, raising exception")
+            debug.lv5(f"Exception: {prettystr(err)}")
             raise err
 
         # Update the name and run
@@ -155,7 +155,7 @@ class Index(Entity):
         self.name = newidx
 
         # Wait for the ILM steps to complete
-        debug.lv3('Waiting for the ILM steps to complete...')
+        debug.lv3("Waiting for the ILM steps to complete...")
         self._ilm_step()
 
         # Track the new index
@@ -168,15 +168,15 @@ class Index(Entity):
         If we are NOT using ILM but have specified searchable snapshots in the plan
         entities
         """
-        if 'target_tier' in scheme and scheme['target_tier'] in ['cold', 'frozen']:
-            debug.lv3('Manually mounting as searchable snapshot...')
+        if "target_tier" in scheme and scheme["target_tier"] in ["cold", "frozen"]:
+            debug.lv3("Manually mounting as searchable snapshot...")
             debug.lv5(
                 f'Mounting "{self.name}" as searchable snapshot '
                 f'({scheme["target_tier"]})'
             )
-            self.snapmgr.add(self.name, scheme['target_tier'])
+            self.snapmgr.add(self.name, scheme["target_tier"])
             # Replace self.name with the renamed name
-            self.name = mounted_name(self.name, scheme['target_tier'])
+            self.name = mounted_name(self.name, scheme["target_tier"])
 
     @begin_end()
     def mount_ss(self, scheme: dict) -> None:
@@ -185,7 +185,7 @@ class Index(Entity):
         if self.am_i_write_idx:
             debug.lv5(
                 f'"{self.name}" is the write_index. Cannot mount as searchable '
-                f'snapshot'
+                f"snapshot"
             )
 
             return
@@ -198,7 +198,7 @@ class Index(Entity):
         debug.lv5(f'Next phase for "{self.name}" = {phase}')
         current = self.ilm_tracker.explain.phase
         debug.lv5(f'Current phase for "{self.name}" = {current}')
-        if current == 'new':
+        if current == "new":
             # This is a problem. We need to be in 'hot', with rollover completed.
             debug.lv3(
                 f'Our index is still in phase "{current}"!. '
@@ -213,22 +213,22 @@ class Index(Entity):
                 phase=self.ilm_tracker.next_phase,
             )
             try:
-                debug.lv4('TRY: Waiting for ILM phase to complete...')
+                debug.lv4("TRY: Waiting for ILM phase to complete...")
                 self._wait_try(phasenext.wait)
             except TestbedFailure as err:
                 logger.error(err.message)
-                debug.lv3('Exiting method, raising exception')
-                debug.lv5(f'Exception: {prettystr(err)}')
+                debug.lv3("Exiting method, raising exception")
+                debug.lv5(f"Exception: {prettystr(err)}")
                 raise err
         target = self._get_target
         debug.lv5(f'Target phase for "{self.name}" = {target}')
         if current != target:
-            debug.lv5(f'Current ({current}) and target ({target}) mismatch')
-            debug.lv5('Waiting for ILM step to complete...')
+            debug.lv5(f"Current ({current}) and target ({target}) mismatch")
+            debug.lv5("Waiting for ILM step to complete...")
             self.ilm_tracker.wait4complete()
             # Because the step is completed, we must now update OUR tracker to
             # reflect the updated ILM Explain information
-            debug.lv5('Updating ILM tracker...')
+            debug.lv5("Updating ILM tracker...")
             self.ilm_tracker.update()
 
             # ILM snapshot mount phase. The biggest pain of them all...
@@ -237,7 +237,7 @@ class Index(Entity):
             debug.lv3(f'ILM advance to phase "{target}" completed')
 
             # Record the snapshot in our tracker
-            debug.lv5('Adding snapshot step to snapmgr...')
+            debug.lv5("Adding snapshot step to snapmgr...")
             self._add_snap_step()
 
     @begin_end()
@@ -247,10 +247,10 @@ class Index(Entity):
         Name as an arg makes it configurable
         """
         if self.policy_name:
-            debug.lv5(f'ILM policy name: {self.policy_name}')
+            debug.lv5(f"ILM policy name: {self.policy_name}")
             debug.lv5(f'Creating ILM tracker for "{name}"')
             self.ilm_tracker = IlmTracker(self.client, name)
             debug.lv5(f'Updating ILM tracker for "{name}"')
             self.ilm_tracker.update()
         else:
-            debug.lv5('No ILM policy name. Skipping ILM tracking')
+            debug.lv5("No ILM policy name. Skipping ILM tracking")

--- a/src/es_testbed/es_api.py
+++ b/src/es_testbed/es_api.py
@@ -34,84 +34,84 @@ PAUSE_VALUE = float(getenv(PAUSE_ENVVAR, default=PAUSE_DEFAULT))
 logger = logging.getLogger(__name__)
 
 
-def emap(kind: str, es: 'Elasticsearch', value=None) -> t.Dict[str, t.Any]:
+def emap(kind: str, es: "Elasticsearch", value=None) -> t.Dict[str, t.Any]:
     """Return a value from a dictionary"""
     _ = {
-        'alias': {
-            'delete': es.indices.delete_alias,
-            'exists': es.indices.exists_alias,
-            'get': es.indices.get_alias,
-            'kwargs': {'index': value, 'expand_wildcards': ['open', 'closed']},
-            'plural': 'alias(es)',
+        "alias": {
+            "delete": es.indices.delete_alias,
+            "exists": es.indices.exists_alias,
+            "get": es.indices.get_alias,
+            "kwargs": {"index": value, "expand_wildcards": ["open", "closed"]},
+            "plural": "alias(es)",
         },
-        'data_stream': {
-            'delete': es.indices.delete_data_stream,
-            'exists': es.indices.exists,
-            'get': es.indices.get_data_stream,
-            'kwargs': {'name': value, 'expand_wildcards': ['open', 'closed']},
-            'plural': 'data_stream(s)',
-            'key': 'data_streams',
+        "data_stream": {
+            "delete": es.indices.delete_data_stream,
+            "exists": es.indices.exists,
+            "get": es.indices.get_data_stream,
+            "kwargs": {"name": value, "expand_wildcards": ["open", "closed"]},
+            "plural": "data_stream(s)",
+            "key": "data_streams",
         },
-        'index': {
-            'delete': es.indices.delete,
-            'exists': es.indices.exists,
-            'get': es.indices.get,
-            'kwargs': {'index': value, 'expand_wildcards': ['open', 'closed']},
-            'plural': 'index(es)',
+        "index": {
+            "delete": es.indices.delete,
+            "exists": es.indices.exists,
+            "get": es.indices.get,
+            "kwargs": {"index": value, "expand_wildcards": ["open", "closed"]},
+            "plural": "index(es)",
         },
-        'template': {
-            'delete': es.indices.delete_index_template,
-            'exists': es.indices.exists_index_template,
-            'get': es.indices.get_index_template,
-            'kwargs': {'name': value},
-            'plural': 'index template(s)',
-            'key': 'index_templates',
+        "template": {
+            "delete": es.indices.delete_index_template,
+            "exists": es.indices.exists_index_template,
+            "get": es.indices.get_index_template,
+            "kwargs": {"name": value},
+            "plural": "index template(s)",
+            "key": "index_templates",
         },
-        'ilm': {
-            'delete': es.ilm.delete_lifecycle,
-            'exists': es.ilm.get_lifecycle,
-            'get': es.ilm.get_lifecycle,
-            'kwargs': {'name': value},
-            'plural': 'ilm policy(ies)',
+        "ilm": {
+            "delete": es.ilm.delete_lifecycle,
+            "exists": es.ilm.get_lifecycle,
+            "get": es.ilm.get_lifecycle,
+            "kwargs": {"name": value},
+            "plural": "ilm policy(ies)",
         },
-        'component': {
-            'delete': es.cluster.delete_component_template,
-            'exists': es.cluster.exists_component_template,
-            'get': es.cluster.get_component_template,
-            'kwargs': {'name': value},
-            'plural': 'component template(s)',
-            'key': 'component_templates',
+        "component": {
+            "delete": es.cluster.delete_component_template,
+            "exists": es.cluster.exists_component_template,
+            "get": es.cluster.get_component_template,
+            "kwargs": {"name": value},
+            "plural": "component template(s)",
+            "key": "component_templates",
         },
-        'snapshot': {
-            'delete': es.snapshot.delete,
-            'exists': es.snapshot.get,
-            'get': es.snapshot.get,
-            'kwargs': {'snapshot': value},
-            'plural': 'snapshot(s)',
+        "snapshot": {
+            "delete": es.snapshot.delete,
+            "exists": es.snapshot.get,
+            "get": es.snapshot.get,
+            "kwargs": {"snapshot": value},
+            "plural": "snapshot(s)",
         },
     }
     return _[kind]
 
 
 @begin_end()
-def change_ds(client: 'Elasticsearch', actions: t.Optional[str] = None) -> None:
+def change_ds(client: "Elasticsearch", actions: t.Optional[str] = None) -> None:
     """Change/Modify/Update a data_stream"""
     try:
-        debug.lv4('TRY: client.indices.modify_data_stream')
-        debug.lv5(f'modify_data_stream actions: {actions}')
+        debug.lv4("TRY: client.indices.modify_data_stream")
+        debug.lv5(f"modify_data_stream actions: {actions}")
         res = client.indices.modify_data_stream(actions=actions, body=None)
-        debug.lv5(f'modify_data_stream response: {res}')
+        debug.lv5(f"modify_data_stream response: {res}")
     except Exception as err:
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
         raise ResultNotExpected(
-            f'Unable to modify data_streams. {prettystr(err)}'
+            f"Unable to modify data_streams. {prettystr(err)}"
         ) from err
 
 
 @begin_end()
 def wait_wrapper(
-    client: 'Elasticsearch',
+    client: "Elasticsearch",
     wait_cls: t.Callable,
     wait_kwargs: t.Dict,
     func: t.Callable,
@@ -119,45 +119,45 @@ def wait_wrapper(
 ) -> None:
     """Wrapper function for waiting on an object to be created"""
     try:
-        debug.lv4('TRY: func()')
-        debug.lv5(f'func kwargs: {f_kwargs}')
+        debug.lv4("TRY: func()")
+        debug.lv5(f"func kwargs: {f_kwargs}")
         func(**f_kwargs)
-        debug.lv4('TRY: wait_cls')
-        debug.lv5(f'wait_cls kwargs: {wait_kwargs}')
+        debug.lv4("TRY: wait_cls")
+        debug.lv5(f"wait_cls kwargs: {wait_kwargs}")
         test = wait_cls(client, **wait_kwargs)
-        debug.lv4('TRY: wait()')
+        debug.lv4("TRY: wait()")
         test.wait()
     except EsWaitFatal as wait:
-        msg = f'{wait.message}. Elapsed time: {wait.elapsed}. Errors: {wait.errors}'
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(wait)}')
+        msg = f"{wait.message}. Elapsed time: {wait.elapsed}. Errors: {wait.errors}"
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(wait)}")
         raise TestbedFailure(msg) from wait
     except EsWaitTimeout as wait:
-        msg = f'{wait.message}. Elapsed time: {wait.elapsed}. Timeout: {wait.timeout}'
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(wait)}')
+        msg = f"{wait.message}. Elapsed time: {wait.elapsed}. Timeout: {wait.timeout}"
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(wait)}")
         raise TestbedFailure(msg) from wait
     except TransportError as err:
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
         raise TestbedFailure(
-            f'Elasticsearch TransportError class exception encountered:'
-            f'{prettystr(err)}'
+            f"Elasticsearch TransportError class exception encountered:"
+            f"{prettystr(err)}"
         ) from err
     except Exception as err:
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
-        raise TestbedFailure(f'General Exception caught: {prettystr(err)}') from err
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
+        raise TestbedFailure(f"General Exception caught: {prettystr(err)}") from err
 
 
 @begin_end()
-def create_data_stream(client: 'Elasticsearch', name: str) -> None:
+def create_data_stream(client: "Elasticsearch", name: str) -> None:
     """Create a data_stream"""
-    wait_kwargs = {'name': name, 'kind': 'data_stream', 'pause': PAUSE_VALUE}
-    debug.lv5(f'wait_kwargs: {wait_kwargs}')
-    f_kwargs = {'name': name}
-    debug.lv5(f'f_kwargs: {f_kwargs}')
-    debug.lv5(f'Creating data_stream {name} and waiting for it to exist')
+    wait_kwargs = {"name": name, "kind": "data_stream", "pause": PAUSE_VALUE}
+    debug.lv5(f"wait_kwargs: {wait_kwargs}")
+    f_kwargs = {"name": name}
+    debug.lv5(f"f_kwargs: {f_kwargs}")
+    debug.lv5(f"Creating data_stream {name} and waiting for it to exist")
     wait_wrapper(
         client, Exists, wait_kwargs, client.indices.create_data_stream, f_kwargs
     )
@@ -165,9 +165,9 @@ def create_data_stream(client: 'Elasticsearch', name: str) -> None:
 
 @begin_end()
 def create_index(
-    client: 'Elasticsearch',
+    client: "Elasticsearch",
     name: str,
-    tier: str = 'hot',
+    tier: str = "hot",
     aliases: t.Optional[t.Dict] = None,
     mappings: t.Optional[t.Dict] = None,
     settings: t.Optional[t.Dict] = None,
@@ -177,101 +177,101 @@ def create_index(
         settings = get_routing(tier=tier)
     else:
         settings.update(get_routing(tier=tier))
-    debug.lv5(f'settings: {settings}')
-    wait_kwargs = {'name': name, 'kind': 'index', 'pause': PAUSE_VALUE}
-    debug.lv5(f'wait_kwargs: {wait_kwargs}')
+    debug.lv5(f"settings: {settings}")
+    wait_kwargs = {"name": name, "kind": "index", "pause": PAUSE_VALUE}
+    debug.lv5(f"wait_kwargs: {wait_kwargs}")
     f_kwargs = {
-        'index': name,
-        'aliases': aliases,
-        'mappings': mappings,
-        'settings': settings,
+        "index": name,
+        "aliases": aliases,
+        "mappings": mappings,
+        "settings": settings,
     }
-    debug.lv5(f'f_kwargs: {f_kwargs}')
-    debug.lv5(f'Creating index {name} and waiting for it to exist')
+    debug.lv5(f"f_kwargs: {f_kwargs}")
+    debug.lv5(f"Creating index {name} and waiting for it to exist")
     wait_wrapper(client, Exists, wait_kwargs, client.indices.create, f_kwargs)
-    retval = exists(client, 'index', name)
-    debug.lv5(f'Return value = {retval}')
+    retval = exists(client, "index", name)
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
 def verify(
-    client: 'Elasticsearch',
+    client: "Elasticsearch",
     kind: str,
     name: str,
     repository: t.Optional[str] = None,
 ) -> bool:
     """Verify that whatever was deleted is actually deleted"""
     success = True
-    items = name.split(',')
+    items = name.split(",")
     for item in items:
         result = exists(client, kind, item, repository=repository)
         if result:  # That means it's still in the cluster
             success = False
-    debug.lv5(f'Return value = {success}')
+    debug.lv5(f"Return value = {success}")
     return success
 
 
 @begin_end()
 def delete(
-    client: 'Elasticsearch',
+    client: "Elasticsearch",
     kind: str,
     name: str,
     repository: t.Optional[str] = None,
 ) -> bool:
     """Delete the named object of type kind"""
     which = emap(kind, client)
-    func = which['delete']
+    func = which["delete"]
     success = False
     if name is not None:  # Typically only with ilm
         try:
-            debug.lv4('TRY: func')
-            if kind == 'snapshot':
-                debug.lv5(f'Deleting snapshot {name} from repository {repository}')
+            debug.lv4("TRY: func")
+            if kind == "snapshot":
+                debug.lv5(f"Deleting snapshot {name} from repository {repository}")
                 res = func(snapshot=name, repository=repository)
-            elif kind == 'index':
-                debug.lv5(f'Deleting index {name}')
+            elif kind == "index":
+                debug.lv5(f"Deleting index {name}")
                 res = func(index=name)
             else:
-                debug.lv5(f'Deleting {kind} {name}')
+                debug.lv5(f"Deleting {kind} {name}")
                 res = func(name=name)
         except NotFoundError as err:
-            debug.lv5(f'{kind} named {name} not found: {prettystr(err)}')
+            debug.lv5(f"{kind} named {name} not found: {prettystr(err)}")
 
-            debug.lv5('Value = True')
+            debug.lv5("Value = True")
             return True
         except Exception as err:
-            debug.lv3('Exiting function, raising exception')
-            debug.lv5(f'Exception: {prettystr(err)}')
-            raise ResultNotExpected(f'Unexpected result: {prettystr(err)}') from err
-        if 'acknowledged' in res and res['acknowledged']:
+            debug.lv3("Exiting function, raising exception")
+            debug.lv5(f"Exception: {prettystr(err)}")
+            raise ResultNotExpected(f"Unexpected result: {prettystr(err)}") from err
+        if "acknowledged" in res and res["acknowledged"]:
             success = True
             debug.lv3(f'Deleted {which["plural"]}: "{name}"')
         else:
-            debug.lv5('Verifying deletion manually')
+            debug.lv5("Verifying deletion manually")
             success = verify(client, kind, name, repository=repository)
     else:
         debug.lv3(f'"{kind}" has a None value for name')
-    debug.lv5(f'Return value = {success}')
+    debug.lv5(f"Return value = {success}")
     return success
 
 
 @begin_end()
 def do_snap(
-    client: 'Elasticsearch', repo: str, snap: str, idx: str, tier: str = 'cold'
+    client: "Elasticsearch", repo: str, snap: str, idx: str, tier: str = "cold"
 ) -> None:
     """Perform a snapshot"""
-    wait_kwargs = {'snapshot': snap, 'repository': repo, 'pause': 1, 'timeout': 60}
-    debug.lv5(f'wait_kwargs: {wait_kwargs}')
-    f_kwargs = {'repository': repo, 'snapshot': snap, 'indices': idx}
-    debug.lv5(f'f_kwargs: {f_kwargs}')
-    debug.lv5(f'Creating snapshot {snap} and waiting for it to complete')
+    wait_kwargs = {"snapshot": snap, "repository": repo, "pause": 1, "timeout": 60}
+    debug.lv5(f"wait_kwargs: {wait_kwargs}")
+    f_kwargs = {"repository": repo, "snapshot": snap, "indices": idx}
+    debug.lv5(f"f_kwargs: {f_kwargs}")
+    debug.lv5(f"Creating snapshot {snap} and waiting for it to complete")
     wait_wrapper(client, Snapshot, wait_kwargs, client.snapshot.create, f_kwargs)
 
     # Mount the index accordingly
     debug.lv5(
-        f'Mounting index {idx} from snapshot {snap} as searchable snapshot '
-        f'with mounted name: {mounted_name(idx, tier)}'
+        f"Mounting index {idx} from snapshot {snap} as searchable snapshot "
+        f"with mounted name: {mounted_name(idx, tier)}"
     )
     client.searchable_snapshots.mount(
         repository=repo,
@@ -283,56 +283,56 @@ def do_snap(
         wait_for_completion=True,
     )
     # Fix aliases
-    debug.lv5(f'Fixing aliases for {idx} to point to {mounted_name(idx, tier)}')
+    debug.lv5(f"Fixing aliases for {idx} to point to {mounted_name(idx, tier)}")
     fix_aliases(client, idx, mounted_name(idx, tier))
 
 
 @begin_end()
 def exists(
-    client: 'Elasticsearch', kind: str, name: str, repository: t.Union[str, None] = None
+    client: "Elasticsearch", kind: str, name: str, repository: t.Union[str, None] = None
 ) -> bool:
     """Return boolean existence of the named kind of object"""
     if name is None:
         return False
     retval = True
-    func = emap(kind, client)['exists']
+    func = emap(kind, client)["exists"]
     try:
-        debug.lv4('TRY: func')
-        if kind == 'snapshot':
+        debug.lv4("TRY: func")
+        if kind == "snapshot":
             # Expected response: {'snapshots': [{'snapshot': name, ...}]}
             # Since we are specifying by name, there should only be one returned
-            debug.lv5(f'Checking for snapshot {name} in repository {repository}')
+            debug.lv5(f"Checking for snapshot {name} in repository {repository}")
             res = func(snapshot=name, repository=repository)
-            debug.lv3(f'Snapshot response: {res}')
+            debug.lv3(f"Snapshot response: {res}")
             # If there are no entries, load a default None value for the check
-            _ = dict(res['snapshots'][0]) if res else {'snapshot': None}
+            _ = dict(res["snapshots"][0]) if res else {"snapshot": None}
             # Since there should be only 1 snapshot with this name, we can check it
-            retval = bool(_['snapshot'] == name)
-        elif kind == 'ilm':
+            retval = bool(_["snapshot"] == name)
+        elif kind == "ilm":
             # There is no true 'exists' method for ILM, so we have to get the policy
             # and check for a NotFoundError
-            debug.lv5(f'Checking for ILM policy {name}')
+            debug.lv5(f"Checking for ILM policy {name}")
             retval = bool(name in dict(func(name=name)))
-        elif kind in ['index', 'data_stream']:
-            debug.lv5(f'Checking for {kind} {name}')
+        elif kind in ["index", "data_stream"]:
+            debug.lv5(f"Checking for {kind} {name}")
             retval = func(index=name)
         else:
-            debug.lv5(f'Checking for {kind} {name}')
+            debug.lv5(f"Checking for {kind} {name}")
             retval = func(name=name)
     except NotFoundError:
-        debug.lv5(f'{kind} named {name} not found')
+        debug.lv5(f"{kind} named {name} not found")
         retval = False
     except Exception as err:
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
-        raise ResultNotExpected(f'Unexpected result: {prettystr(err)}') from err
-    debug.lv5(f'Return value = {retval}')
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
+        raise ResultNotExpected(f"Unexpected result: {prettystr(err)}") from err
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
 def fill_index(
-    client: 'Elasticsearch',
+    client: "Elasticsearch",
     name: t.Optional[str] = None,
     doc_generator: t.Optional[t.Generator[t.Dict, None, None]] = None,
     options: t.Optional[t.Dict] = None,
@@ -355,34 +355,34 @@ def fill_index(
 
 
 @begin_end()
-def find_write_index(client: 'Elasticsearch', name: str) -> t.AnyStr:
+def find_write_index(client: "Elasticsearch", name: str) -> t.AnyStr:
     """Find the write_index for an alias by searching any index the alias points to"""
     retval = None
     for alias in get_aliases(client, name):
-        debug.lv5(f'Inspecting alias: {alias}')
+        debug.lv5(f"Inspecting alias: {alias}")
         retval = get_write_index(client, alias)
-        debug.lv5(f'find_write_index response: {retval}')
+        debug.lv5(f"find_write_index response: {retval}")
         if retval:
-            debug.lv5(f'Found write index: {retval}')
+            debug.lv5(f"Found write index: {retval}")
             break
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def fix_aliases(client: 'Elasticsearch', oldidx: str, newidx: str) -> None:
+def fix_aliases(client: "Elasticsearch", oldidx: str, newidx: str) -> None:
     """Fix aliases using the new and old index names as data"""
     # Delete the original index
-    debug.lv5(f'Deleting index {oldidx}')
+    debug.lv5(f"Deleting index {oldidx}")
     client.indices.delete(index=oldidx)
     # Add the original index name as an alias to the mounted index
-    debug.lv5(f'Adding alias {oldidx} to index {newidx}')
-    client.indices.put_alias(index=f'{newidx}', name=oldidx)
+    debug.lv5(f"Adding alias {oldidx} to index {newidx}")
+    client.indices.put_alias(index=f"{newidx}", name=oldidx)
 
 
 @begin_end()
 def get(
-    client: 'Elasticsearch',
+    client: "Elasticsearch",
     kind: str,
     pattern: str,
     repository: t.Optional[str] = None,
@@ -393,68 +393,68 @@ def get(
         logger.error(msg)
         raise TestbedMisconfig(msg)
     which = emap(kind, client, value=pattern)
-    func = which['get']
-    kwargs = which['kwargs']
-    if kind == 'snapshot':
-        kwargs['repository'] = repository
+    func = which["get"]
+    kwargs = which["kwargs"]
+    if kind == "snapshot":
+        kwargs["repository"] = repository
     try:
-        debug.lv4('TRY: func')
-        debug.lv5(f'func kwargs: {kwargs}')
+        debug.lv4("TRY: func")
+        debug.lv5(f"func kwargs: {kwargs}")
         result = func(**kwargs)
     except NotFoundError:
         debug.lv3(f'{kind} pattern "{pattern}" had zero matches')
         return []
     except Exception as err:
-        raise ResultNotExpected(f'Unexpected result: {prettystr(err)}') from err
-    if kind == 'snapshot':
-        debug.lv5('Checking for snapshot')
-        retval = [x['snapshot'] for x in result['snapshots']]
-    elif kind in ['data_stream', 'template', 'component']:
-        debug.lv5('Checking for data_stream/template/component')
-        retval = [x['name'] for x in result[which['key']]]
+        raise ResultNotExpected(f"Unexpected result: {prettystr(err)}") from err
+    if kind == "snapshot":
+        debug.lv5("Checking for snapshot")
+        retval = [x["snapshot"] for x in result["snapshots"]]
+    elif kind in ["data_stream", "template", "component"]:
+        debug.lv5("Checking for data_stream/template/component")
+        retval = [x["name"] for x in result[which["key"]]]
     else:
-        debug.lv5('Checking for alias/ilm/index')
+        debug.lv5("Checking for alias/ilm/index")
         retval = list(result.keys())
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def get_aliases(client: 'Elasticsearch', name: str) -> t.Sequence[str]:
+def get_aliases(client: "Elasticsearch", name: str) -> t.Sequence[str]:
     """Get aliases from index 'name'"""
     res = client.indices.get(index=name)
-    debug.lv5(f'get_aliases response: {res}')
+    debug.lv5(f"get_aliases response: {res}")
     try:
-        debug.lv4('TRY: getting aliases')
-        retval = list(res[name]['aliases'].keys())
+        debug.lv4("TRY: getting aliases")
+        retval = list(res[name]["aliases"].keys())
         debug.lv5(f"list(res[name]['aliases'].keys()) = {retval}")
     except KeyError:
         retval = None
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def get_backing_indices(client: 'Elasticsearch', name: str) -> t.Sequence[str]:
+def get_backing_indices(client: "Elasticsearch", name: str) -> t.Sequence[str]:
     """Get the backing indices from the named data_stream"""
     resp = resolver(client, name)
-    data_streams = resp['data_streams']
+    data_streams = resp["data_streams"]
     retval = []
     if data_streams:
-        debug.lv5('Checking for backing indices...')
+        debug.lv5("Checking for backing indices...")
         if len(data_streams) > 1:
-            debug.lv3('Exiting function, raising exception')
-            debug.lv5(f'ResultNotExpected: More than 1 found {data_streams}')
+            debug.lv3("Exiting function, raising exception")
+            debug.lv5(f"ResultNotExpected: More than 1 found {data_streams}")
             raise ResultNotExpected(
-                f'Expected only a single data_stream matching {name}'
+                f"Expected only a single data_stream matching {name}"
             )
-        retval = data_streams[0]['backing_indices']
-    debug.lv5(f'Return value = {retval}')
+        retval = data_streams[0]["backing_indices"]
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def get_ds_current(client: 'Elasticsearch', name: str) -> str:
+def get_ds_current(client: "Elasticsearch", name: str) -> str:
     """
     Find which index is the current 'write' index of the data_stream
     This is best accomplished by grabbing the last backing_index
@@ -463,45 +463,45 @@ def get_ds_current(client: 'Elasticsearch', name: str) -> str:
     retval = None
     if backers:
         retval = backers[-1]
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def get_ilm(client: 'Elasticsearch', pattern: str) -> t.Union[t.Dict[str, str], None]:
+def get_ilm(client: "Elasticsearch", pattern: str) -> t.Union[t.Dict[str, str], None]:
     """Get any ILM entity in ES that matches pattern"""
     try:
-        debug.lv4('TRY: ilm.get_lifecycle')
+        debug.lv4("TRY: ilm.get_lifecycle")
         retval = client.ilm.get_lifecycle(name=pattern)
     except Exception as err:
-        msg = f'Unable to get ILM lifecycle matching {pattern}. Error: {prettystr(err)}'
+        msg = f"Unable to get ILM lifecycle matching {pattern}. Error: {prettystr(err)}"
         logger.critical(msg)
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
         raise ResultNotExpected(msg) from err
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def get_ilm_phases(client: 'Elasticsearch', name: str) -> t.Dict:
+def get_ilm_phases(client: "Elasticsearch", name: str) -> t.Dict:
     """Return the policy/phases part of the ILM policy identified by 'name'"""
     ilm = get_ilm(client, name)
     try:
-        debug.lv4('TRY: get ILM phases')
-        retval = ilm[name]['policy']['phases']
+        debug.lv4("TRY: get ILM phases")
+        retval = ilm[name]["policy"]["phases"]
     except KeyError as err:
-        msg = f'Unable to get ILM lifecycle named {name}. Error: {prettystr(err)}'
+        msg = f"Unable to get ILM lifecycle named {name}. Error: {prettystr(err)}"
         logger.critical(msg)
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
         raise ResultNotExpected(msg) from err
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def get_write_index(client: 'Elasticsearch', name: str) -> str:
+def get_write_index(client: "Elasticsearch", name: str) -> str:
     """
     Calls :py:meth:`~.elasticsearch.client.IndicesClient.get_alias`
 
@@ -514,71 +514,71 @@ def get_write_index(client: 'Elasticsearch', name: str) -> str:
     ``is_write_index``
     """
     response = client.indices.get_alias(index=name)
-    debug.lv5(f'get_alias response: {response}')
+    debug.lv5(f"get_alias response: {response}")
     retval = None
     for index in list(response.keys()):
         try:
-            debug.lv4('TRY: get write index')
-            if response[index]['aliases'][name]['is_write_index']:
+            debug.lv4("TRY: get write index")
+            if response[index]["aliases"][name]["is_write_index"]:
                 retval = index
                 break
         except KeyError:
             continue
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
-def ilm_explain(client: 'Elasticsearch', name: str) -> t.Union[t.Dict, None]:
+def ilm_explain(client: "Elasticsearch", name: str) -> t.Union[t.Dict, None]:
     """Return the results from the ILM Explain API call for the named index"""
     try:
-        debug.lv4('TRY: ilm.explain_lifecycle')
-        retval = client.ilm.explain_lifecycle(index=name)['indices'][name]
+        debug.lv4("TRY: ilm.explain_lifecycle")
+        retval = client.ilm.explain_lifecycle(index=name)["indices"][name]
     except KeyError:
-        debug.lv5('Index name changed')
-        new = list(client.ilm.explain_lifecycle(index=name)['indices'].keys())[0]
-        debug.lv5(f'ilm.explain_lifecycle response: {new}')
-        retval = client.ilm.explain_lifecycle(index=new)['indices'][new]
+        debug.lv5("Index name changed")
+        new = list(client.ilm.explain_lifecycle(index=name)["indices"].keys())[0]
+        debug.lv5(f"ilm.explain_lifecycle response: {new}")
+        retval = client.ilm.explain_lifecycle(index=new)["indices"][new]
     except NotFoundError as err:
-        logger.warning(f'Datastream/Index Name changed. {name} was not found')
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
-        raise NameChanged(f'{name} was not found, likely due to a name change') from err
+        logger.warning(f"Datastream/Index Name changed. {name} was not found")
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
+        raise NameChanged(f"{name} was not found, likely due to a name change") from err
     except Exception as err:
-        msg = f'Unable to get ILM information for index {name}'
+        msg = f"Unable to get ILM information for index {name}"
         logger.critical(msg)
-        debug.lv3('Exiting function, raising exception')
-        debug.lv5(f'Exception: {prettystr(err)}')
-        raise ResultNotExpected(f'{msg}. Exception: {prettystr(err)}') from err
-    debug.lv5(f'Return value = {retval}')
+        debug.lv3("Exiting function, raising exception")
+        debug.lv5(f"Exception: {prettystr(err)}")
+        raise ResultNotExpected(f"{msg}. Exception: {prettystr(err)}") from err
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
 @begin_end()
 def ilm_move(
-    client: 'Elasticsearch', name: str, current_step: t.Dict, next_step: t.Dict
+    client: "Elasticsearch", name: str, current_step: t.Dict, next_step: t.Dict
 ) -> None:
     """Move index 'name' from the current step to the next step"""
     try:
-        debug.lv4('TRY: ilm.move_to_step')
+        debug.lv4("TRY: ilm.move_to_step")
         res = client.ilm.move_to_step(
             index=name, current_step=current_step, next_step=next_step
         )
-        debug.lv5(f'ilm.move_to_step response: {res}')
+        debug.lv5(f"ilm.move_to_step response: {res}")
     except Exception as err:
         msg = (
-            f'Unable to move index {name} to ILM next step: {next_step}. '
-            f'Error: {prettystr(err)}'
+            f"Unable to move index {name} to ILM next step: {next_step}. "
+            f"Error: {prettystr(err)}"
         )
         logger.critical(msg)
         raise ResultNotExpected(msg, (err,))
 
 
 @begin_end()
-def put_comp_tmpl(client: 'Elasticsearch', name: str, component: t.Dict) -> None:
+def put_comp_tmpl(client: "Elasticsearch", name: str, component: t.Dict) -> None:
     """Publish a component template"""
-    wait_kwargs = {'name': name, 'kind': 'component_template', 'pause': PAUSE_VALUE}
-    f_kwargs = {'name': name, 'template': component, 'create': True}
+    wait_kwargs = {"name": name, "kind": "component_template", "pause": PAUSE_VALUE}
+    f_kwargs = {"name": name, "template": component, "create": True}
     wait_wrapper(
         client,
         Exists,
@@ -590,20 +590,20 @@ def put_comp_tmpl(client: 'Elasticsearch', name: str, component: t.Dict) -> None
 
 @begin_end()
 def put_idx_tmpl(
-    client: 'Elasticsearch',
+    client: "Elasticsearch",
     name: str,
     index_patterns: t.List[str],
     components: t.List[str],
     data_stream: t.Optional[t.Dict] = None,
 ) -> None:
     """Publish an index template"""
-    wait_kwargs = {'name': name, 'kind': 'index_template', 'pause': PAUSE_VALUE}
+    wait_kwargs = {"name": name, "kind": "index_template", "pause": PAUSE_VALUE}
     f_kwargs = {
-        'name': name,
-        'composed_of': components,
-        'data_stream': data_stream,
-        'index_patterns': index_patterns,
-        'create': True,
+        "name": name,
+        "composed_of": components,
+        "data_stream": data_stream,
+        "index_patterns": index_patterns,
+        "create": True,
     }
     wait_wrapper(
         client,
@@ -616,22 +616,22 @@ def put_idx_tmpl(
 
 @begin_end()
 def put_ilm(
-    client: 'Elasticsearch', name: str, policy: t.Union[t.Dict, None] = None
+    client: "Elasticsearch", name: str, policy: t.Union[t.Dict, None] = None
 ) -> None:
     """Publish an ILM Policy"""
     try:
-        debug.lv4('TRY: ilm.put_lifecycle')
-        debug.lv5(f'ilm.put_lifecycle name: {name}, policy: {policy}')
+        debug.lv4("TRY: ilm.put_lifecycle")
+        debug.lv5(f"ilm.put_lifecycle name: {name}, policy: {policy}")
         res = client.ilm.put_lifecycle(name=name, policy=policy)
-        debug.lv5(f'ilm.put_lifecycle response: {res}')
+        debug.lv5(f"ilm.put_lifecycle response: {res}")
     except Exception as err:
-        msg = f'Unable to put ILM policy {name}. Error: {prettystr(err)}'
+        msg = f"Unable to put ILM policy {name}. Error: {prettystr(err)}"
         logger.error(msg)
         raise TestbedFailure(msg) from err
 
 
 @begin_end()
-def resolver(client: 'Elasticsearch', name: str) -> dict:
+def resolver(client: "Elasticsearch", name: str) -> dict:
     """
     Resolve details about the entity, be it an index, alias, or data_stream
 
@@ -643,30 +643,30 @@ def resolver(client: 'Elasticsearch', name: str) -> dict:
     If you only resolve a single index or data stream, you will still have a 1-element
     list
     """
-    _ = client.indices.resolve_index(name=name, expand_wildcards=['open', 'closed'])
-    debug.lv5(f'Return value = {_}')
+    _ = client.indices.resolve_index(name=name, expand_wildcards=["open", "closed"])
+    debug.lv5(f"Return value = {_}")
     return _
 
 
 @begin_end()
-def rollover(client: 'Elasticsearch', name: str) -> None:
+def rollover(client: "Elasticsearch", name: str) -> None:
     """Rollover alias or data_stream identified by name"""
-    res = client.indices.rollover(alias=name, wait_for_active_shards='all')
-    debug.lv5(f'rollover response: {res}')
+    res = client.indices.rollover(alias=name, wait_for_active_shards="all")
+    debug.lv5(f"rollover response: {res}")
 
 
 @begin_end()
-def snapshot_name(client: 'Elasticsearch', name: str) -> t.Union[t.AnyStr, None]:
+def snapshot_name(client: "Elasticsearch", name: str) -> t.Union[t.AnyStr, None]:
     """Get the name of the snapshot behind the mounted index data"""
     res = {}
-    if exists(client, 'index', name):  # Can jump straight to nested keys if it exists
-        res = client.indices.get(index=name)[name]['settings']['index']
-        debug.lv5(f'indices.get response: {res}')
+    if exists(client, "index", name):  # Can jump straight to nested keys if it exists
+        res = client.indices.get(index=name)[name]["settings"]["index"]
+        debug.lv5(f"indices.get response: {res}")
     try:
         debug.lv4("TRY: retval = res['store']['snapshot']['snapshot_name']")
-        retval = res['store']['snapshot']['snapshot_name']
+        retval = res["store"]["snapshot"]["snapshot_name"]
     except KeyError:
-        logger.error(f'{name} is not a searchable snapshot')
+        logger.error(f"{name} is not a searchable snapshot")
         retval = None
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval

--- a/src/es_testbed/mgrs/__init__.py
+++ b/src/es_testbed/mgrs/__init__.py
@@ -8,10 +8,10 @@ from .snapshot import SnapshotMgr
 from .template import TemplateMgr
 
 __all__ = [
-    'ComponentMgr',
-    'DataStreamMgr',
-    'IlmMgr',
-    'IndexMgr',
-    'SnapshotMgr',
-    'TemplateMgr',
+    "ComponentMgr",
+    "DataStreamMgr",
+    "IlmMgr",
+    "IndexMgr",
+    "SnapshotMgr",
+    "TemplateMgr",
 ]

--- a/src/es_testbed/mgrs/component.py
+++ b/src/es_testbed/mgrs/component.py
@@ -19,30 +19,30 @@ logger = logging.getLogger(__name__)
 class ComponentMgr(EntityMgr):
     """Component Template Entity Manager Class"""
 
-    kind = 'component'
-    listname = 'component_templates'
+    kind = "component"
+    listname = "component_templates"
 
     def __init__(
         self,
-        client: t.Union['Elasticsearch', None] = None,
-        plan: t.Union['DotMap', None] = None,
+        client: t.Union["Elasticsearch", None] = None,
+        plan: t.Union["DotMap", None] = None,
     ):
-        debug.lv2('Initializing ComponentMgr object...')
+        debug.lv2("Initializing ComponentMgr object...")
         super().__init__(client=client, plan=plan)
-        debug.lv3('ComponentMgr object initialized')
+        debug.lv3("ComponentMgr object initialized")
 
     @property
     @begin_end()
     def components(self) -> t.Sequence[t.Dict]:
         """Return a list of component template dictionaries"""
         retval = []
-        preset = import_module(f'{self.plan.modpath}.definitions')
+        preset = import_module(f"{self.plan.modpath}.definitions")
         val = preset.settings()
         if self.plan.ilm_policies[-1]:
-            val['settings']['index.lifecycle.name'] = self.plan.ilm_policies[-1]
+            val["settings"]["index.lifecycle.name"] = self.plan.ilm_policies[-1]
             if self.plan.rollover_alias:
-                val['settings'][
-                    'index.lifecycle.rollover_alias'
+                val["settings"][
+                    "index.lifecycle.rollover_alias"
                 ] = self.plan.rollover_alias
         retval.append(val)
         retval.append(preset.mappings())
@@ -55,10 +55,10 @@ class ComponentMgr(EntityMgr):
             put_comp_tmpl(self.client, self.name, component)
             if not exists(self.client, self.kind, self.name):
                 raise ResultNotExpected(
-                    f'Unable to verify creation of component template {self.name}'
+                    f"Unable to verify creation of component template {self.name}"
                 )
             self.appender(self.name)
         logger.info(
-            f'Successfully created all component templates: '
-            f'{prettystr(self.entity_list)}'
+            f"Successfully created all component templates: "
+            f"{prettystr(self.entity_list)}"
         )

--- a/src/es_testbed/mgrs/data_stream.py
+++ b/src/es_testbed/mgrs/data_stream.py
@@ -1,5 +1,6 @@
 """data_stream Entity Manager Class"""
 
+# pylint: disable=W0221
 import typing as t
 import logging
 from importlib import import_module
@@ -20,25 +21,25 @@ logger = logging.getLogger(__name__)
 class DataStreamMgr(IndexMgr):
     """data_stream Entity Manager Class"""
 
-    kind = 'data_stream'
-    listname = 'data_stream'
+    kind = "data_stream"
+    listname = "data_stream"
 
     def __init__(
         self,
-        client: t.Union['Elasticsearch', None] = None,
-        plan: t.Union['DotMap', None] = None,
+        client: t.Union["Elasticsearch", None] = None,
+        plan: t.Union["DotMap", None] = None,
         snapmgr: t.Union[SnapshotMgr, None] = None,
     ):
         self.ds = None
         self.index_trackers = []
-        debug.lv3('Initializing DataStreamMgr object...')
+        debug.lv3("Initializing DataStreamMgr object...")
         super().__init__(client=client, plan=plan, snapmgr=snapmgr)
-        debug.lv3('DataStreamMgr object initialized')
+        debug.lv3("DataStreamMgr object initialized")
 
     @property
     def suffix(self):
         """Return nothing, as there is no index count suffix to a data_stream name"""
-        return ''
+        return ""
 
     @property
     def indexlist(self) -> t.Sequence[str]:
@@ -49,10 +50,10 @@ class DataStreamMgr(IndexMgr):
     def add(self, value):
         """Create a data stream and track it"""
         try:
-            debug.lv4(f'TRY: Creating data_stream {value}')
+            debug.lv4(f"TRY: Creating data_stream {value}")
             create_data_stream(self.client, value)
         except Exception as err:
-            logger.critical(f'Error creating data_stream: {prettystr(err)}')
+            logger.critical(f"Error creating data_stream: {prettystr(err)}")
             raise err
         self.track_data_stream()
 
@@ -61,15 +62,15 @@ class DataStreamMgr(IndexMgr):
         """If the indices were marked as searchable snapshots, we do that now"""
         for idx, scheme in enumerate(self.plan.index_buildlist):
             self.index_trackers[idx].mount_ss(scheme)
-        logger.info('Completed backing index promotion to searchable snapshots.')
-        debug.lv5(f'data_stream backing indices: {prettystr(self.ds.backing_indices)}')
+        logger.info("Completed backing index promotion to searchable snapshots.")
+        debug.lv5(f"data_stream backing indices: {prettystr(self.ds.backing_indices)}")
 
     @begin_end()
     def setup(self) -> None:
         """Setup the entity manager"""
         self.index_trackers = []  # Inheritance oddity requires redeclaration here
-        mod = import_module(f'{self.plan.modpath}.functions')
-        func = getattr(mod, 'doc_generator')
+        mod = import_module(f"{self.plan.modpath}.functions")
+        func = getattr(mod, "doc_generator")
         for scheme in self.plan.index_buildlist:
             if not self.entity_list:
                 self.add(self.name)
@@ -79,23 +80,23 @@ class DataStreamMgr(IndexMgr):
                 self.client,
                 name=self.name,
                 doc_generator=func,
-                options=scheme['options'],
+                options=scheme["options"],
             )
-        debug.lv2(f'Created data_stream: {self.ds.name}')
+        debug.lv2(f"Created data_stream: {self.ds.name}")
         debug.lv3(
-            f'Created data_stream backing indices: {prettystr(self.ds.backing_indices)}'
+            f"Created data_stream backing indices: {prettystr(self.ds.backing_indices)}"
         )
         for index in self.ds.backing_indices:
             self.track_index(index)
         self.ds.verify(self.indexlist)
         self.searchable()
         self.ds.verify(self.indexlist)
-        logger.info('Successfully completed data_stream buildout.')
+        logger.info("Successfully completed data_stream buildout.")
 
     @begin_end()
     def track_data_stream(self) -> None:
         """Add a DataStream entity and append it to entity_list"""
-        debug.lv3(f'Tracking data_stream: {self.name}')
+        debug.lv3(f"Tracking data_stream: {self.name}")
         self.ds = DataStream(client=self.client, name=self.name)
         self.appender(self.name)
 

--- a/src/es_testbed/mgrs/entity.py
+++ b/src/es_testbed/mgrs/entity.py
@@ -11,13 +11,13 @@ if t.TYPE_CHECKING:
 class EntityMgr:
     """Entity Manager Parent Class"""
 
-    kind = 'entity_type'
-    listname = 'entity_mgrs'
+    kind = "entity_type"
+    listname = "entity_mgrs"
 
     def __init__(
         self,
-        client: t.Union['Elasticsearch', None] = None,
-        plan: t.Union['DotMap', None] = None,
+        client: t.Union["Elasticsearch", None] = None,
+        plan: t.Union["DotMap", None] = None,
     ):
         self.client = client
         self.plan = plan
@@ -34,7 +34,7 @@ class EntityMgr:
     @property
     def entity_root(self) -> str:
         """The entity root name builder"""
-        return f'{self.plan.prefix}-{self.ident()}-{self.plan.uniq}'
+        return f"{self.plan.prefix}-{self.ident()}-{self.plan.uniq}"
 
     @property
     def indexlist(self) -> t.Sequence[str]:
@@ -49,17 +49,17 @@ class EntityMgr:
     @property
     def name(self) -> str:
         """Return the full, incrementing name of a not yet appended entity"""
-        return f'{self.entity_root}{self.suffix}'
+        return f"{self.entity_root}{self.suffix}"
 
     @property
     def pattern(self) -> str:
         """Return the search pattern for the managed entity"""
-        return f'*{self.entity_root}*'
+        return f"*{self.entity_root}*"
 
     @property
     def suffix(self) -> str:
         """Return the incrementing index suffix"""
-        return f'-{len(self.entity_list) + 1:06}'
+        return f"-{len(self.entity_list) + 1:06}"
 
     def appender(self, name: str) -> None:
         """Append an item to entity_list"""

--- a/src/es_testbed/mgrs/ilm.py
+++ b/src/es_testbed/mgrs/ilm.py
@@ -18,32 +18,32 @@ logger = logging.getLogger(__name__)
 class IlmMgr(EntityMgr):
     """Index Lifecycle Policy Entity Manager"""
 
-    kind = 'ilm'
-    listname = 'ilm_policies'
+    kind = "ilm"
+    listname = "ilm_policies"
 
     def __init__(
         self,
-        client: t.Union['Elasticsearch', None] = None,
-        plan: t.Union['DotMap', None] = None,
+        client: t.Union["Elasticsearch", None] = None,
+        plan: t.Union["DotMap", None] = None,
     ):
         """Initialize the ILM policy manager"""
-        debug.lv2('Initializing IlmMgr object...')
+        debug.lv2("Initializing IlmMgr object...")
         super().__init__(client=client, plan=plan)
-        debug.lv3('IlmMgr object initialized')
+        debug.lv3("IlmMgr object initialized")
 
     @begin_end()
     def get_policy(self) -> t.Dict:
         """Return the configured ILM policy"""
         d = self.plan.ilm
         kwargs = {
-            'phases': d.phases,
-            'forcemerge': d.forcemerge,
-            'max_num_segments': d.max_num_segments,
-            'readonly': d.readonly,
-            'repository': self.plan.repository,
+            "phases": d.phases,
+            "forcemerge": d.forcemerge,
+            "max_num_segments": d.max_num_segments,
+            "readonly": d.readonly,
+            "repository": self.plan.repository,
         }
         retval = build_ilm_policy(**kwargs)
-        debug.lv5(f'Return value = {retval}')
+        debug.lv5(f"Return value = {retval}")
         return retval
 
     @begin_end()
@@ -54,14 +54,14 @@ class IlmMgr(EntityMgr):
                 self.plan.ilm.policy = self.get_policy()
             put_ilm(self.client, self.name, policy=self.plan.ilm.policy)
             # Verify existence
-            if not exists(self.client, 'ilm', self.name):
+            if not exists(self.client, "ilm", self.name):
                 raise ResultNotExpected(
-                    f'Unable to verify creation of ilm policy {self.name}'
+                    f"Unable to verify creation of ilm policy {self.name}"
                 )
             # This goes first because the length of entity_list determines the suffix
             self.appender(self.name)
-            logger.info(f'Successfully created ILM policy: {self.last}')
+            logger.info(f"Successfully created ILM policy: {self.last}")
             debug.lv5(self.client.ilm.get_lifecycle(name=self.last))
         else:
             self.appender(None)  # This covers self.plan.ilm_policies[-1]
-            logger.info('No ILM policy created.')
+            logger.info("No ILM policy created.")

--- a/src/es_testbed/mgrs/index.py
+++ b/src/es_testbed/mgrs/index.py
@@ -20,20 +20,20 @@ logger = logging.getLogger(__name__)
 class IndexMgr(EntityMgr):
     """Index Entity Manager Class"""
 
-    kind = 'index'
-    listname = 'indices'
+    kind = "index"
+    listname = "indices"
 
     def __init__(
         self,
-        client: t.Optional['Elasticsearch'] = None,
-        plan: t.Optional['DotMap'] = None,
+        client: t.Optional["Elasticsearch"] = None,
+        plan: t.Optional["DotMap"] = None,
         snapmgr: t.Optional[SnapshotMgr] = None,
     ):
         self.snapmgr = snapmgr
         self.alias = None  # Only used for tracking the rollover alias
-        debug.lv2('Initializing IndexMgr object...')
+        debug.lv2("Initializing IndexMgr object...")
         super().__init__(client=client, plan=plan)
-        debug.lv3('IndexMgr object initialized')
+        debug.lv3("IndexMgr object initialized")
 
     @property
     def indexlist(self) -> t.Sequence[str]:
@@ -51,16 +51,16 @@ class IndexMgr(EntityMgr):
     def _rollover_path(self) -> None:
         """This is the execution path for rollover indices"""
         if not self.entity_list:
-            acfg = {self.plan.rollover_alias: {'is_write_index': True}}
-            debug.lv5(f'Creating index with config: {acfg}')
+            acfg = {self.plan.rollover_alias: {"is_write_index": True}}
+            debug.lv5(f"Creating index with config: {acfg}")
             create_index(self.client, self.name, aliases=acfg)
             self.track_alias()
         else:
             self.alias.rollover()
-            debug.lv5('Rolled over index with alias')
+            debug.lv5("Rolled over index with alias")
             if self.policy_name:  # We have an ILM policy
-                kw = {'phase': 'hot', 'action': 'complete', 'name': 'complete'}
-                debug.lv5(f'Advancing ILM policy with config: {kw}')
+                kw = {"phase": "hot", "action": "complete", "name": "complete"}
+                debug.lv5(f"Advancing ILM policy with config: {kw}")
                 self.last.ilm_tracker.advance(**kw)
 
     @begin_end()
@@ -71,19 +71,19 @@ class IndexMgr(EntityMgr):
         settings: t.Optional[t.Dict] = None,
     ) -> None:
         """Create a single index"""
-        mapvals = mappings['mappings'] or None
-        setvals = settings['settings']['index'] or None
+        mapvals = mappings["mappings"] or None
+        setvals = settings["settings"]["index"] or None
         debug.lv1(f'Creating index: "{name}"')
-        debug.lv5(f'-- with settings: {settings}')
-        debug.lv5(f'-- with mappings: {mappings}')
+        debug.lv5(f"-- with settings: {settings}")
+        debug.lv5(f"-- with mappings: {mappings}")
         create_index(self.client, name, mappings=mapvals, settings=setvals)
 
     @begin_end()
     def add_indices(self) -> None:
         """Add indices according to plan"""
-        args = import_module(f'{self.plan.modpath}.definitions')
-        mod = import_module(f'{self.plan.modpath}.functions')
-        func = getattr(mod, 'doc_generator')
+        args = import_module(f"{self.plan.modpath}.definitions")
+        mod = import_module(f"{self.plan.modpath}.functions")
+        func = getattr(mod, "doc_generator")
         for scheme in self.plan.index_buildlist:
             if self.plan.rollover_alias:
                 self._rollover_path()
@@ -94,14 +94,14 @@ class IndexMgr(EntityMgr):
                 self.client,
                 name=self.name,
                 doc_generator=func,
-                options=scheme['options'],
+                options=scheme["options"],
             )
             self.track_index(self.name)
-        debug.lv2(f'Created indices: {prettystr(self.indexlist)}')
+        debug.lv2(f"Created indices: {prettystr(self.indexlist)}")
         if self.plan.rollover_alias:
             if not self.alias.verify(self.indexlist):
                 logger.error(
-                    f'Unable to confirm rollover of alias '
+                    f"Unable to confirm rollover of alias "
                     f'"{self.plan.rollover_alias}" was successful'
                 )
 
@@ -109,29 +109,29 @@ class IndexMgr(EntityMgr):
     def searchable(self) -> None:
         """If the indices were marked as searchable snapshots, we do that now"""
         for idx, scheme in enumerate(self.plan.index_buildlist):
-            if scheme['target_tier'] in ['cold', 'frozen']:
+            if scheme["target_tier"] in ["cold", "frozen"]:
                 self.entity_list[idx].mount_ss(scheme)
 
     @begin_end()
     def setup(self) -> None:
         """Setup the entity manager"""
-        debug.lv5(f'PLAN: {prettystr(self.plan.toDict())}')
+        debug.lv5(f"PLAN: {prettystr(self.plan.toDict())}")
         if self.plan.rollover_alias:
-            debug.lv3('rollover_alias is True...')
+            debug.lv3("rollover_alias is True...")
         self.add_indices()
         self.searchable()
-        logger.info(f'Successfully created indices: {prettystr(self.indexlist)}')
+        logger.info(f"Successfully created indices: {prettystr(self.indexlist)}")
 
     @begin_end()
     def track_alias(self) -> None:
         """Track a rollover alias"""
-        debug.lv3(f'Tracking alias: {self.plan.rollover_alias}')
+        debug.lv3(f"Tracking alias: {self.plan.rollover_alias}")
         self.alias = Alias(client=self.client, name=self.plan.rollover_alias)
 
     @begin_end()
     def track_index(self, name: str) -> None:
         """Track an index and append that tracking entity to entity_list"""
-        debug.lv3(f'Tracking index: {name}')
+        debug.lv3(f"Tracking index: {name}")
         entity = Index(
             client=self.client,
             name=name,

--- a/src/es_testbed/mgrs/snapshot.py
+++ b/src/es_testbed/mgrs/snapshot.py
@@ -16,22 +16,22 @@ logger = logging.getLogger(__name__)
 class SnapshotMgr(EntityMgr):
     """Snapshot Entity Manager Class"""
 
-    kind = 'snapshot'
-    listname = 'snapshots'
+    kind = "snapshot"
+    listname = "snapshots"
 
     def __init__(
         self,
-        client: t.Union['Elasticsearch', None] = None,
-        plan: t.Union['DotMap', None] = None,
+        client: t.Union["Elasticsearch", None] = None,
+        plan: t.Union["DotMap", None] = None,
     ):
-        debug.lv2('Initializing SnapshotMgr object...')
+        debug.lv2("Initializing SnapshotMgr object...")
         super().__init__(client=client, plan=plan)
-        debug.lv3('SnapshotMgr object initialized')
+        debug.lv3("SnapshotMgr object initialized")
 
     @begin_end()
     def add(self, index: str, tier: str) -> None:
         """Perform a snapshot and add it to the entity_list"""
-        msg = f'Creating snapshot of index {index} and mounting in the {tier} tier...'
+        msg = f"Creating snapshot of index {index} and mounting in the {tier} tier..."
         debug.lv3(msg)
         do_snap(self.client, self.plan.repository, self.name, index, tier=tier)
         self.appender(self.name)
@@ -40,5 +40,5 @@ class SnapshotMgr(EntityMgr):
     @begin_end()
     def add_existing(self, name: str) -> None:
         """Add a snapshot that's already been created, e.g. by ILM promotion"""
-        debug.lv3(f'Adding snapshot {name} to list...')
+        debug.lv3(f"Adding snapshot {name} to list...")
         self.appender(name)

--- a/src/es_testbed/mgrs/template.py
+++ b/src/es_testbed/mgrs/template.py
@@ -17,17 +17,17 @@ logger = logging.getLogger(__name__)
 class TemplateMgr(EntityMgr):
     """Index Template entity manager"""
 
-    kind = 'template'
-    listname = 'index_templates'
+    kind = "template"
+    listname = "index_templates"
 
     def __init__(
         self,
-        client: t.Union['Elasticsearch', None] = None,
-        plan: t.Union['DotMap', None] = None,
+        client: t.Union["Elasticsearch", None] = None,
+        plan: t.Union["DotMap", None] = None,
     ):
-        debug.lv2('Initializing TemplateMgr object...')
+        debug.lv2("Initializing TemplateMgr object...")
         super().__init__(client=client, plan=plan)
-        debug.lv3('TemplateMgr object initialized')
+        debug.lv3("TemplateMgr object initialized")
 
     @property
     def patterns(self) -> t.Sequence[str]:
@@ -40,14 +40,14 @@ class TemplateMgr(EntityMgr):
     @begin_end()
     def get_pattern(self, kind: str) -> str:
         """Return the a formatted index search pattern string"""
-        retval = f'{self.plan.prefix}-{self.ident(dkey=kind)}-{self.plan.uniq}'
-        debug.lv5(f'Return value = {retval}')
+        retval = f"{self.plan.prefix}-{self.ident(dkey=kind)}-{self.plan.uniq}"
+        debug.lv5(f"Return value = {retval}")
         return retval
 
     @begin_end()
     def setup(self) -> None:
         """Setup the entity manager"""
-        ds = {} if self.plan.type == 'data_stream' else None
+        ds = {} if self.plan.type == "data_stream" else None
         put_idx_tmpl(
             self.client,
             self.name,
@@ -57,7 +57,7 @@ class TemplateMgr(EntityMgr):
         )
         if not exists(self.client, self.kind, self.name):
             raise ResultNotExpected(
-                f'Unable to verify creation of index template {self.name}'
+                f"Unable to verify creation of index template {self.name}"
             )
         self.appender(self.name)
-        debug.lv3(f'Successfully created index template: {self.last}')
+        debug.lv3(f"Successfully created index template: {self.last}")

--- a/src/es_testbed/presets/searchable_test/definitions.py
+++ b/src/es_testbed/presets/searchable_test/definitions.py
@@ -12,12 +12,12 @@ logger = logging.getLogger(__name__)
 
 def baseplan() -> dict:
     """Return the base plan object from plan.yml"""
-    return get_yaml((modpath() / 'plan.yml'))
+    return get_yaml((modpath() / "plan.yml"))
 
 
 def buildlist() -> list:
     """Return the list of index build schemas from buildlist.yml"""
-    return get_yaml((modpath() / 'buildlist.yml'))
+    return get_yaml((modpath() / "buildlist.yml"))
 
 
 def get_plan(scenario: t.Optional[str] = None) -> dict:
@@ -25,19 +25,19 @@ def get_plan(scenario: t.Optional[str] = None) -> dict:
     retval = baseplan()
     retval.update(buildlist())
     if scenario:
-        retval['uniq'] = f'scenario-{scenario}'
+        retval["uniq"] = f"scenario-{scenario}"
         scenarios = Scenarios()
         newvals = getattr(scenarios, scenario)
-        ilm = newvals.pop('ilm', {})
+        ilm = newvals.pop("ilm", {})
         if ilm:
-            retval['ilm'].update(ilm)
+            retval["ilm"].update(ilm)
         retval.update(newvals)
     return retval
 
 
 def mappings() -> dict:
     """Return the index mappings from mappings.json"""
-    return loads((modpath() / 'mappings.json').read_text(encoding='UTF-8'))
+    return loads((modpath() / "mappings.json").read_text(encoding="UTF-8"))
 
 
 def modpath() -> Path:
@@ -47,4 +47,4 @@ def modpath() -> Path:
 
 def settings() -> dict:
     """Return the index settings from settings.json"""
-    return loads((modpath() / 'settings.json').read_text(encoding='UTF-8'))
+    return loads((modpath() / "settings.json").read_text(encoding="UTF-8"))

--- a/src/es_testbed/presets/searchable_test/functions.py
+++ b/src/es_testbed/presets/searchable_test/functions.py
@@ -35,14 +35,14 @@ def iso8601_now() -> str:
     +00:00, but could in theory sometime show up as a Z, so we test for that.
     """
 
-    parts = datetime.now(timezone.utc).isoformat().split('+')
+    parts = datetime.now(timezone.utc).isoformat().split("+")
     if len(parts) == 1:
-        if parts[0][-1] == 'Z':
+        if parts[0][-1] == "Z":
             return parts[0]  # _______ It already ends with a Z for Zulu/UTC time
-        return f'{parts[0]}Z'  # _____ It doesn't end with a Z so we put one there
-    if parts[1] == '00:00':
-        return f'{parts[0]}Z'  # _____ It doesn't end with a Z so we put one there
-    return f'{parts[0]}+{parts[1]}'  # Fallback publishes the +TZ, whatever that was
+        return f"{parts[0]}Z"  # _____ It doesn't end with a Z so we put one there
+    if parts[1] == "00:00":
+        return f"{parts[0]}Z"  # _____ It doesn't end with a Z so we put one there
+    return f"{parts[0]}+{parts[1]}"  # Fallback publishes the +TZ, whatever that was
 
 
 def randomstr(length: int = 16, lowercase: bool = False) -> str:
@@ -54,7 +54,7 @@ def randomstr(length: int = 16, lowercase: bool = False) -> str:
     letters = string.ascii_uppercase
     if lowercase:
         letters = string.ascii_lowercase
-    return str(''.join(random.choices(letters + string.digits, k=length)))
+    return str("".join(random.choices(letters + string.digits, k=length)))
 
 
 def doc_generator(
@@ -68,7 +68,7 @@ def doc_generator(
         match is True, a random value between 1001 and 32767 if False)
     :returns: A generator shipping docs
     """
-    keys = ['message', 'nested', 'deep']
+    keys = ["message", "nested", "deep"]
     # Start with an empty map
     matchmap = {}
     # Iterate over each key
@@ -84,11 +84,11 @@ def doc_generator(
     # This is where count and start_at matter
     for num in range(start_at, start_at + count):
         yield {
-            '@timestamp': iso8601_now(),
-            'message': f'{matchmap["message"]}{num}',  # message# or randomstr#
-            'number': (
+            "@timestamp": iso8601_now(),
+            "message": f'{matchmap["message"]}{num}',  # message# or randomstr#
+            "number": (
                 num if match else random.randint(1001, 32767)
             ),  # value of num or random int
-            'nested': {'key': f'{matchmap["nested"]}{num}'},  # nested#
-            'deep': {'l1': {'l2': {'l3': f'{matchmap["deep"]}{num}'}}},  # deep#
+            "nested": {"key": f'{matchmap["nested"]}{num}'},  # nested#
+            "deep": {"l1": {"l2": {"l3": f'{matchmap["deep"]}{num}'}}},  # deep#
         }

--- a/src/es_testbed/presets/searchable_test/scenarios.py
+++ b/src/es_testbed/presets/searchable_test/scenarios.py
@@ -11,7 +11,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-REPOSITORY = environ.get('TEST_ES_REPO', 'found-snapshots')
+REPOSITORY = environ.get("TEST_ES_REPO", "found-snapshots")
 
 # default values = {
 #     'type': 'indices',
@@ -32,7 +32,7 @@ class Scenarios:
 
     def __init__(self):
         """Initialize the scenarios for this preset"""
-        _ = 'init'  # Add to avoid empty function body
+        _ = "init"  # Add to avoid empty function body
 
     # #####################
     # ### Hot Scenarios ###
@@ -41,17 +41,17 @@ class Scenarios:
     @property
     def hot(self):
         """Basic hot scenario"""
-        return self.scenario_builder('hot', 'basic')
+        return self.scenario_builder("hot", "basic")
 
     @property
     def hot_rollover(self):
         """Hot rollover index scenario"""
-        return self.scenario_builder('hot', 'rollover')
+        return self.scenario_builder("hot", "rollover")
 
     @property
     def hot_ds(self):
         """Hot data_stream scenario"""
-        return self.scenario_builder('hot', 'data_stream')
+        return self.scenario_builder("hot", "data_stream")
 
     # ######################
     # ### Cold Scenarios ###
@@ -60,22 +60,22 @@ class Scenarios:
     @property
     def cold(self):
         """Basic cold scenario"""
-        return self.scenario_builder('cold', 'basic')
+        return self.scenario_builder("cold", "basic")
 
     @property
     def cold_rollover(self):
         """Cold rollover index scenario"""
-        return self.scenario_builder('cold', 'rollover')
+        return self.scenario_builder("cold", "rollover")
 
     @property
     def cold_ilm(self):
         """Cold ilm index scenario"""
-        return self.scenario_builder('cold', 'ilm')
+        return self.scenario_builder("cold", "ilm")
 
     @property
     def cold_ds(self):
         """Cold data_stream scenario"""
-        return self.scenario_builder('cold', 'data_stream')
+        return self.scenario_builder("cold", "data_stream")
 
     # ########################
     # ### Frozen Scenarios ###
@@ -84,69 +84,69 @@ class Scenarios:
     @property
     def frozen(self):
         """Basic frozen scenario"""
-        return self.scenario_builder('frozen', 'basic')
+        return self.scenario_builder("frozen", "basic")
 
     @property
     def frozen_rollover(self):
         """Frozen rollover index scenario"""
-        return self.scenario_builder('frozen', 'rollover')
+        return self.scenario_builder("frozen", "rollover")
 
     @property
     def frozen_ilm(self):
         """Frozen ilm index scenario"""
-        return self.scenario_builder('frozen', 'ilm')
+        return self.scenario_builder("frozen", "ilm")
 
     @property
     def frozen_ds(self):
         """Frozen data_stream scenario"""
-        return self.scenario_builder('frozen', 'data_stream')
+        return self.scenario_builder("frozen", "data_stream")
 
     def build_list(self) -> t.Sequence[t.Dict]:
         """The plan build list for these scenarios"""
         return [
             {
-                'options': {
-                    'count': 10,
-                    'start_at': i * 10,
-                    'match': True,
+                "options": {
+                    "count": 10,
+                    "start_at": i * 10,
+                    "match": True,
                 },
-                'target_tier': 'frozen' if i < 2 else 'hot',
+                "target_tier": "frozen" if i < 2 else "hot",
             }
             for i in range(3)
         ]
 
     def define_ilm(
         self,
-        phase: t.Literal['hot', 'warm', 'cold', 'frozen'],
-        subtype: t.Literal['basic', 'rollover', 'ilm', 'data_stream'],
+        phase: t.Literal["hot", "warm", "cold", "frozen"],
+        subtype: t.Literal["basic", "rollover", "ilm", "data_stream"],
     ) -> t.Union[t.Dict, bool]:
         """Return ILM based on subtype"""
-        retval = {'enabled': False, 'phases': ['hot', 'delete']}
-        if phase in ['cold', 'frozen']:
-            retval['phases'].append(phase)
-        if subtype in ['ilm', 'data_stream']:
-            retval['enabled'] = True
+        retval = {"enabled": False, "phases": ["hot", "delete"]}
+        if phase in ["cold", "frozen"]:
+            retval["phases"].append(phase)
+        if subtype in ["ilm", "data_stream"]:
+            retval["enabled"] = True
         return retval
 
     def scenario_builder(
         self,
-        phase: t.Literal['hot', 'warm', 'cold', 'frozen'] = 'hot',
-        subtype: t.Literal['basic', 'rollover', 'ilm', 'data_stream'] = 'basic',
+        phase: t.Literal["hot", "warm", "cold", "frozen"] = "hot",
+        subtype: t.Literal["basic", "rollover", "ilm", "data_stream"] = "basic",
     ) -> t.Dict:
         """Build a scenario"""
         retval = {
-            'repository': REPOSITORY,
-            'index_buildlist': self.build_list(),
-            'ilm': {'enabled': False, 'phases': ['hot', 'delete']},
+            "repository": REPOSITORY,
+            "index_buildlist": self.build_list(),
+            "ilm": {"enabled": False, "phases": ["hot", "delete"]},
         }
-        for idx in range(len(retval['index_buildlist'])):
+        for idx in range(len(retval["index_buildlist"])):
             # By default, make everything have the phase as the target_tier
-            retval['index_buildlist'][idx]['target_tier'] = phase
-        if subtype != 'basic':
+            retval["index_buildlist"][idx]["target_tier"] = phase
+        if subtype != "basic":
             # The last entry should always be hot in rollover, ilm, and data_stream
-            retval['index_buildlist'][-1]['target_tier'] = 'hot'
-        if subtype in ['rollover', 'ilm']:
-            retval['rollover_alias'] = True
-        retval['ilm'] = self.define_ilm(phase, subtype)
-        retval['type'] = 'data_stream' if subtype == 'data_stream' else 'indices'
+            retval["index_buildlist"][-1]["target_tier"] = "hot"
+        if subtype in ["rollover", "ilm"]:
+            retval["rollover_alias"] = True
+        retval["ilm"] = self.define_ilm(phase, subtype)
+        retval["type"] = "data_stream" if subtype == "data_stream" else "indices"
         return retval

--- a/src/es_testbed/utils.py
+++ b/src/es_testbed/utils.py
@@ -27,21 +27,21 @@ def build_ilm_phase(
 ) -> t.Dict:
     """Build a single ILM policy step based on phase"""
     retval = ilm_phase(phase)
-    if phase in ['cold', 'frozen']:
+    if phase in ["cold", "frozen"]:
         if repo:
-            retval[phase]['actions']['searchable_snapshot'] = {
-                'snapshot_repository': repo,
-                'force_merge_index': fm,
+            retval[phase]["actions"]["searchable_snapshot"] = {
+                "snapshot_repository": repo,
+                "force_merge_index": fm,
             }
         else:
             msg = (
-                f'Unable to build {phase} ILM phase. Value for repository not '
-                f'provided'
+                f"Unable to build {phase} ILM phase. Value for repository not "
+                f"provided"
             )
             raise TestbedMisconfig(msg)
     if actions:
-        retval[phase]['actions'].update(actions)
-    debug.lv5(f'Return value = {retval}')
+        retval[phase]["actions"].update(actions)
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
@@ -58,10 +58,10 @@ def build_ilm_policy(
     Put forcemerge in the last phase before cold or frozen (whichever comes first)
     """
     if not phases:
-        phases = ['hot', 'delete']
+        phases = ["hot", "delete"]
     retval = {}
-    if ('cold' in phases or 'frozen' in phases) and not repository:
-        raise TestbedMisconfig('Cannot build cold or frozen phase without repository')
+    if ("cold" in phases or "frozen" in phases) and not repository:
+        raise TestbedMisconfig("Cannot build cold or frozen phase without repository")
     for phase in phases:
         actions = None
         if readonly == phase:
@@ -69,24 +69,24 @@ def build_ilm_policy(
         phase = build_ilm_phase(phase, repo=repository, fm=forcemerge, actions=actions)
         retval.update(phase)
     if forcemerge:
-        retval['hot']['actions'].update(
+        retval["hot"]["actions"].update(
             ilm_force_merge(max_num_segments=max_num_segments)
         )
-    debug.lv5("Value = {'phases': " + f'{retval}' + "}")
-    return {'phases': retval}
+    debug.lv5("Value = {'phases': " + f"{retval}" + "}")
+    return {"phases": retval}
 
 
 @begin_end()
-def get_routing(tier='hot') -> t.Dict:
+def get_routing(tier="hot") -> t.Dict:
     """Return the routing allocation tier preference"""
     try:
-        debug.lv4(f'Checking for tier: {tier}')
-        pref = TIER[tier]['pref']
+        debug.lv4(f"Checking for tier: {tier}")
+        pref = TIER[tier]["pref"]
     except KeyError:
         # Fallback value
-        pref = 'data_content'
-    retval = {'index.routing.allocation.include._tier_preference': pref}
-    debug.lv5(f'Return value = {retval}')
+        pref = "data_content"
+    retval = {"index.routing.allocation.include._tier_preference": pref}
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
@@ -113,21 +113,21 @@ def iso8601_now() -> str:
     #
     # We are MANUALLY, FORCEFULLY declaring timezone.utc, so it should ALWAYS be
     # +00:00, but could in theory sometime show up as a Z, so we test for that.
-    parts = datetime.datetime.now(datetime.timezone.utc).isoformat().split('+')
+    parts = datetime.datetime.now(datetime.timezone.utc).isoformat().split("+")
     if len(parts) == 1:
-        if parts[0][-1] == 'Z':
+        if parts[0][-1] == "Z":
             return parts[0]  # Our ISO8601 already ends with a Z for Zulu/UTC time
-        return f'{parts[0]}Z'  # It doesn't end with a Z so we put one there
-    if parts[1] == '00:00':
-        return f'{parts[0]}Z'  # It doesn't end with a Z so we put one there
-    return f'{parts[0]}+{parts[1]}'  # Fallback publishes the +TZ, whatever that was
+        return f"{parts[0]}Z"  # It doesn't end with a Z so we put one there
+    if parts[1] == "00:00":
+        return f"{parts[0]}Z"  # It doesn't end with a Z so we put one there
+    return f"{parts[0]}+{parts[1]}"  # Fallback publishes the +TZ, whatever that was
 
 
 @begin_end()
 def mounted_name(index: str, tier: str):
     """Return a value for renamed_index for mounting a searchable snapshot index"""
     retval = f'{TIER[tier]["prefix"]}-{index}'
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
@@ -145,16 +145,16 @@ def prettystr(*args, **kwargs) -> str:
     3.10 and up, so there is a test here to add it when that is the case.
     """
     defaults = [
-        ('indent', 2),
-        ('width', 80),
-        ('depth', None),
-        ('compact', False),
-        ('sort_dicts', False),
+        ("indent", 2),
+        ("width", 80),
+        ("depth", None),
+        ("compact", False),
+        ("sort_dicts", False),
     ]
     vinfo = python_version()
     if vinfo[0] == 3 and vinfo[1] >= 10:
         # underscore_numbers only works in 3.10 and up
-        defaults.append(('underscore_numbers', False))
+        defaults.append(("underscore_numbers", False))
     kw = {}
     for tup in defaults:
         key, default = tup
@@ -180,24 +180,24 @@ def process_preset(
     modpath = None
     tmpdir = None
     if builtin:  # Overrides any other options
-        modpath = f'es_testbed.presets.{builtin}'
+        modpath = f"es_testbed.presets.{builtin}"
     else:
         trygit = False
         try:
-            debug.lv4('TRY: Checking for git preset')
-            kw = {'path': path, 'ref': ref, 'url': url}
+            debug.lv4("TRY: Checking for git preset")
+            kw = {"path": path, "ref": ref, "url": url}
             raise_on_none(**kw)
             trygit = True  # We have all 3 kwargs necessary for git
         except ValueError as resp:  # Not able to do a git preset
-            debug.lv1(f'Unable to import a git-based preset: {resp}')
+            debug.lv1(f"Unable to import a git-based preset: {resp}")
         if trygit:  # Trying a git import
             tmpdir = mkdtemp()
             try:
-                debug.lv4('TRY: Attempting to clone git repository')
+                debug.lv4("TRY: Attempting to clone git repository")
                 _ = Repo.clone_from(url, tmpdir, branch=ref, depth=1)
                 filepath = Path(tmpdir) / path
             except Exception as err:
-                logger.error(f'Git clone failed: {err}')
+                logger.error(f"Git clone failed: {err}")
                 rmtree(tmpdir)  # Clean up after failed attempt
                 raise err
         filepath = Path(path)  # It should work even if path is None
@@ -207,7 +207,7 @@ def process_preset(
         parent = filepath.parent.resolve()  # Up one level
         # We now make the parent path part of the sys.path.
         sys.path.insert(0, parent)  # This should persist beyond this module
-    debug.lv5(f'Return value = ({modpath}, {tmpdir})')
+    debug.lv5(f"Return value = ({modpath}, {tmpdir})")
     return modpath, tmpdir
 
 
@@ -218,7 +218,7 @@ def python_version() -> t.Tuple:
     """
     _ = sys.version_info
     retval = (_[0], _[1], _[2])
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
@@ -227,7 +227,7 @@ def raise_on_none(**kwargs):
     """Raise if any kwargs have a None value"""
     for key, value in kwargs.items():
         if value is None:
-            debug.lv3('Exiting function, raising ValueError')
+            debug.lv3("Exiting function, raising ValueError")
             raise ValueError(f'kwarg "{key}" cannot have a None value')
 
 
@@ -237,8 +237,8 @@ def randomstr(length: int = 16, lowercase: bool = False) -> str:
     letters = string.ascii_uppercase
     if lowercase:
         letters = string.ascii_lowercase
-    retval = str(''.join(random.choices(letters + string.digits, k=length)))
-    debug.lv5(f'Return value = {retval}')
+    retval = str("".join(random.choices(letters + string.digits, k=length)))
+    debug.lv5(f"Return value = {retval}")
     return retval
 
 
@@ -246,5 +246,5 @@ def randomstr(length: int = 16, lowercase: bool = False) -> str:
 def storage_type(tier: str) -> t.Dict:
     """Return the storage type of a searchable snapshot by tier"""
     retval = TIER[tier]["storage"]
-    debug.lv5(f'Return value = {retval}')
+    debug.lv5(f"Return value = {retval}")
     return retval

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -5,13 +5,13 @@ import pytest
 from es_testbed import TestBed
 from es_testbed.presets.searchable_test.definitions import get_plan
 
-INDEX1: str = 'index1'
+INDEX1: str = "index1"
 """Default index name for testing."""
 
 SETTINGS: dict = {
-    'index': {
-        'number_of_shards': 1,
-        'number_of_replicas': 0,
+    "index": {
+        "number_of_shards": 1,
+        "number_of_replicas": 0,
     },
 }
 """Default index settings for testing."""
@@ -23,28 +23,28 @@ logger = logging.getLogger(__name__)
 
 def get_kind(scenario) -> str:
     """Return the searchable snapshot tier for the test based on plan"""
-    return get_plan(scenario=scenario)['type']
+    return get_plan(scenario=scenario)["type"]
 
 
 def get_sstier(scenario) -> str:
     """Return the searchable snapshot tier for the test based on plan"""
     plan = get_plan(scenario=scenario)
     tiers = set()
-    for scheme in plan['index_buildlist']:
-        if 'target_tier' in scheme:
-            if scheme['target_tier'] in ['cold', 'frozen']:
-                tiers.add(scheme['target_tier'])
-    if 'ilm' in plan:
-        if 'phases' in plan['ilm']:
-            for phase in ['cold', 'frozen']:
-                if phase in plan['ilm']['phases']:
+    for scheme in plan["index_buildlist"]:
+        if "target_tier" in scheme:
+            if scheme["target_tier"] in ["cold", "frozen"]:
+                tiers.add(scheme["target_tier"])
+    if "ilm" in plan:
+        if "phases" in plan["ilm"]:
+            for phase in ["cold", "frozen"]:
+                if phase in plan["ilm"]["phases"]:
                     tiers.add(phase)
     if len(tiers) > 1:
-        raise ValueError('Both cold and frozen tiers specified for this scenario!')
+        raise ValueError("Both cold and frozen tiers specified for this scenario!")
     if tiers:
         retval = list(tiers)[0]  # There can be only one...
     else:
-        retval = 'hot'
+        retval = "hot"
     return retval
 
 
@@ -60,10 +60,10 @@ class TestAny:
     @pytest.fixture(scope="class")
     def tb(self, client, prefix, uniq, skip_no_repo):  # skip_localhost fixed?
         """TestBed setup/teardown"""
-        skip_no_repo(get_sstier(self.scenario) in ['cold', 'frozen'])
-        teebee = TestBed(client, builtin='searchable_test', scenario=self.scenario)
-        teebee.settings['prefix'] = prefix
-        teebee.settings['uniq'] = uniq
+        skip_no_repo(get_sstier(self.scenario) in ["cold", "frozen"])
+        teebee = TestBed(client, builtin="searchable_test", scenario=self.scenario)
+        teebee.settings["prefix"] = prefix
+        teebee.settings["uniq"] = uniq
         teebee.setup()
         yield teebee
         teebee.teardown()
@@ -80,24 +80,24 @@ class TestAny:
         """
         expected = rollovername(tb.plan)
         actual = actual_rollover(tb)
-        logger.debug('expected = %s', expected)
-        logger.debug('actual = %s', actual)
+        logger.debug("expected = %s", expected)
+        logger.debug("actual = %s", actual)
         assert actual == expected
 
     def test_first_index(self, actual_index, first, index_name, tb):
         """Assert that the first index matches the expected name"""
         expected = index_name(which=first, plan=tb.plan, tier=get_sstier(self.scenario))
         actual = actual_index(tb, first)
-        logger.debug('expected = %s', expected)
-        logger.debug('actual = %s', actual)
+        logger.debug("expected = %s", expected)
+        logger.debug("actual = %s", actual)
         assert actual == expected
 
     def test_last_index(self, actual_index, index_name, last, tb):
         """Assert that the last index matches the expected name"""
         expected = index_name(which=last, plan=tb.plan, tier=get_sstier(self.scenario))
         actual = actual_index(tb, last)
-        logger.debug('expected = %s', expected)
-        logger.debug('actual = %s', actual)
+        logger.debug("expected = %s", expected)
+        logger.debug("actual = %s", actual)
         assert actual == expected
 
     def test_write_index(self, tb, actual_write_index, write_index_name):
@@ -108,8 +108,8 @@ class TestAny:
         """
         expected = write_index_name(plan=tb.plan, tier=get_sstier(self.scenario))
         actual = actual_write_index(tb)
-        logger.debug('expected = %s', expected)
-        logger.debug('actual = %s', actual)
+        logger.debug("expected = %s", expected)
+        logger.debug("actual = %s", actual)
         assert actual == expected
 
     def test_index_template(self, tb, components, get_template, template):
@@ -118,4 +118,4 @@ class TestAny:
         assert tb.templatemgr.last == template
         result = get_template(tb.client)
         assert len(result) == 1
-        assert result[0]['index_template']['composed_of'] == components
+        assert result[0]["index_template"]["composed_of"] == components

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,11 +16,11 @@ from es_testbed.debug import debug
 from es_testbed.defaults import NAMEMAPPER
 from es_testbed.es_api import get_ds_current, get_write_index
 
-LOGLEVEL = 'DEBUG'
-LOCALREPO = 'testing'
-PROJ = path.abspath(path.join(path.dirname(__file__), '..'))
-ENVPATH = path.join(PROJ, '.env')
-print(f'ENVPATH: {ENVPATH}')
+LOGLEVEL = "DEBUG"
+LOCALREPO = "testing"
+PROJ = path.abspath(path.join(path.dirname(__file__), ".."))
+ENVPATH = path.join(PROJ, ".env")
+print(f"ENVPATH: {ENVPATH}")
 
 debug.level = 5  # Set the debug level to 5 for all tests
 wait_debug.level = debug.level  # Set the wait_debug level to match the debug level
@@ -40,81 +40,81 @@ class Index4Test:
         self.client.indices.delete(index=self.name)
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def actual_index(entitymgr):
     def _actual_index(tb, which):
-        if tb.plan.type == 'data_stream':
+        if tb.plan.type == "data_stream":
             return entitymgr(tb).ds.backing_indices[which]
         return entitymgr(tb).entity_list[which].name  # implied else
 
     return _actual_index
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def actual_rollover(entitymgr):
     def _actual_rollover(tb):
-        if tb.plan.type == 'data_stream':
+        if tb.plan.type == "data_stream":
             return entitymgr(tb).last
         if tb.plan.rollover_alias:
             if entitymgr(tb).alias.name is not None:
                 return entitymgr(tb).alias.name
-        return ''  # implied else
+        return ""  # implied else
 
     return _actual_rollover
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def actual_write_index(actual_rollover):
     def _actual_write_index(tb):
         name = actual_rollover(tb)
         if not name:
             return name
         func = get_write_index
-        if tb.plan.type == 'data_stream':
+        if tb.plan.type == "data_stream":
             func = get_ds_current
         return func(tb.client, name)
 
     return _actual_write_index
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def client():
     """Return an Elasticsearch client"""
     load_dotenv(dotenv_path=ENVPATH)
-    host = environ.get('TEST_ES_SERVER')
-    user = environ.get('TEST_USER')
-    pswd = environ.get('TEST_PASS')
-    cacrt = environ.get('CA_CRT')
-    file = environ.get('ES_CLIENT_FILE', None)  # Path to es_client YAML config
-    repo = environ.get('TEST_ES_REPO', 'found-snapshots')
+    host = environ.get("TEST_ES_SERVER")
+    user = environ.get("TEST_USER")
+    pswd = environ.get("TEST_PASS")
+    cacrt = environ.get("CA_CRT")
+    file = environ.get("ES_CLIENT_FILE", None)  # Path to es_client YAML config
+    repo = environ.get("TEST_ES_REPO", "found-snapshots")
     if file:
-        kwargs = {'configfile': file}
+        kwargs = {"configfile": file}
     else:
         kwargs = {
-            'configdict': {
-                'elasticsearch': {
-                    'client': {'hosts': host, 'ca_certs': cacrt},
-                    'other_settings': {'username': user, 'password': pswd},
+            "configdict": {
+                "elasticsearch": {
+                    "client": {"hosts": host, "ca_certs": cacrt},
+                    "other_settings": {"username": user, "password": pswd},
                 }
             }
         }
-    set_logging({'loglevel': LOGLEVEL, 'blacklist': ['elastic_transport', 'urllib3']})
+    set_logging({"loglevel": LOGLEVEL, "blacklist": ["elastic_transport", "urllib3"]})
     builder = Builder(**kwargs)
     builder.connect()
     # This is a contradiction that cannot exist...
-    if repo == 'found-snapshots' and host == 'https://127.0.0.1:9200' and not file:
+    if repo == "found-snapshots" and host == "https://127.0.0.1:9200" and not file:
         # Reset the env var
-        environ['TEST_ES_REPO'] = LOCALREPO
+        environ["TEST_ES_REPO"] = LOCALREPO
     return builder.client
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def cold():
     """Return the prefix for cold indices"""
-    return 'restored-'
+    return "restored-"
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def components(namecore):
     """Return the component names in a list"""
     components = []
@@ -136,13 +136,13 @@ def idxcfg(request):
 @pytest.fixture
 def create_idx(client, name, idxcfg):
     # Setup
-    print(f'Creating index {name} with settings {idxcfg}')
+    print(f"Creating index {name} with settings {idxcfg}")
     index = Index4Test(client, name, idxcfg)
     index.setup()
     yield index
 
     # Teardown
-    print(f'Teardown: Deleting index {name}')
+    print(f"Teardown: Deleting index {name}")
     index.teardown()
 
 
@@ -156,119 +156,119 @@ def create_repository(client, name: str) -> None:
         }
     }
     """
-    repobody = {'type': 'fs', 'settings': {'location': '/media'}}
+    repobody = {"type": "fs", "settings": {"location": "/media"}}
     client.snapshot.create_repository(name=name, repository=repobody, verify=False)
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def entity_count(defaults):
     def _entity_count(kind):
-        if kind == 'data_stream':
+        if kind == "data_stream":
             return 1
-        return defaults()['count']
+        return defaults()["count"]
 
     return _entity_count
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def defaults() -> t.Dict:
-    def _defaults(sstier: str = 'hot') -> t.Dict:
-        retval = {'count': 3, 'docs': 10, 'match': True, 'searchable': None}
-        if sstier in ['cold', 'frozen']:
-            retval['searchable'] = sstier
+    def _defaults(sstier: str = "hot") -> t.Dict:
+        retval = {"count": 3, "docs": 10, "match": True, "searchable": None}
+        if sstier in ["cold", "frozen"]:
+            retval["searchable"] = sstier
         return retval
 
     return _defaults
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def entitymgr():
     def _entitymgr(tb):
-        if tb.plan.type == 'data_stream':
+        if tb.plan.type == "data_stream":
             return tb.data_streammgr
         return tb.indexmgr  # implied else
 
     return _entitymgr
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def first():
     return 0
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def frozen():
     """Return the prefix for frozen indices"""
-    return 'partial-'
+    return "partial-"
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def get_template(template):
     def _get_template(client):
-        return client.indices.get_index_template(name=template)['index_templates']
+        return client.indices.get_index_template(name=template)["index_templates"]
 
     return _get_template
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def idxmain(namecore, ymd):
     def _idxmain(kind):
-        result = f'{namecore(kind)}'
-        if kind == 'data_stream':
-            return f'.ds-{result}-{ymd}'
+        result = f"{namecore(kind)}"
+        if kind == "data_stream":
+            return f".ds-{result}-{ymd}"
         return result
 
     return _idxmain
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def idxss(first, ssprefix, rollable):
     def _idxss(tier, which, plan):
         if which != first:
             if rollable(plan):
-                return ''  # No searchable prefix
+                return ""  # No searchable prefix
         return ssprefix(tier)
 
     return _idxss
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def idxtail(first, last):
     def _idxtail(which):
         if which == first:
-            return '-000001'
+            return "-000001"
         if which == last:
-            return '-000003'
-        return '-000002'  # implied else
+            return "-000003"
+        return "-000002"  # implied else
 
     return _idxtail
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def index_name(first, idxmain, idxss, idxtail):
-    def _index_name(which=first, plan=None, tier: str = 'hot'):
+    def _index_name(which=first, plan=None, tier: str = "hot"):
         prefix = idxss(tier, which, plan)
         main = idxmain(plan.type)
         suffix = idxtail(which)
-        return f'{prefix}{main}{suffix}'
+        return f"{prefix}{main}{suffix}"
 
     return _index_name
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def last():
     return -1
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def namecore(prefix, uniq):
     def _namecore(kind):
-        return f'{prefix}-{NAMEMAPPER[kind]}-{uniq}'
+        return f"{prefix}-{NAMEMAPPER[kind]}-{uniq}"
 
     return _namecore
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def prefix():
     """Return a random prefix"""
     return randomstr(length=8, lowercase=True)
@@ -279,14 +279,14 @@ def randomstr(length: int = 16, lowercase: bool = False):
     letters = string.ascii_uppercase
     if lowercase:
         letters = string.ascii_lowercase
-    return str(''.join(random.choices(letters + string.digits, k=length)))
+    return str("".join(random.choices(letters + string.digits, k=length)))
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def repo(client):
     """Return the elasticsearch repository"""
     load_dotenv(dotenv_path=ENVPATH)
-    name = environ.get('TEST_ES_REPO', 'found-snapshots')  # Going with Cloud default
+    name = environ.get("TEST_ES_REPO", "found-snapshots")  # Going with Cloud default
     if not repo:
         return False
     try:
@@ -296,10 +296,10 @@ def repo(client):
     return name  # Return the repo name if it's online
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def rollable():
     def _rollable(plan):
-        if plan.type == 'data_stream':
+        if plan.type == "data_stream":
             return True
         if plan.rollover_alias:
             return True
@@ -308,102 +308,102 @@ def rollable():
     return _rollable
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def rollovername(namecore, rollable):
     def _rollovername(plan):
         if rollable(plan):
             return namecore(plan.type)
-        return ''
+        return ""
 
     return _rollovername
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def settings(defaults, prefix, repo, uniq):
     def _settings(
-        plan_type: t.Literal['data_stream', 'index'] = 'data_stream',
+        plan_type: t.Literal["data_stream", "index"] = "data_stream",
         rollover_alias: bool = False,
         ilm: t.Union[t.Dict, False] = False,
-        sstier: str = 'hot',
+        sstier: str = "hot",
     ):
         return {
-            'type': plan_type,
-            'prefix': prefix,
-            'rollover_alias': rollover_alias,
-            'repository': repo,
-            'uniq': uniq,
-            'ilm': ilm,
-            'defaults': defaults(sstier),
+            "type": plan_type,
+            "prefix": prefix,
+            "rollover_alias": rollover_alias,
+            "repository": repo,
+            "uniq": uniq,
+            "ilm": ilm,
+            "defaults": defaults(sstier),
         }
 
     return _settings
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def skip_no_repo(repo) -> None:
     def _skip_no_repo(skip_it: bool) -> None:
         if skip_it:
             if not repo:
-                pytest.skip('No snapshot repository', allow_module_level=True)
+                pytest.skip("No snapshot repository", allow_module_level=True)
 
     return _skip_no_repo
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def skip_localhost() -> None:
     def _skip_localhost(skip_it: bool) -> None:
         if skip_it:
             load_dotenv(dotenv_path=ENVPATH)
-            host = environ.get('TEST_ES_SERVER')
-            file = environ.get('ES_CLIENT_FILE', None)  # Path to es_client YAML config
-            repo = environ.get('TEST_ES_REPO')
-            if repo == LOCALREPO and host == 'https://127.0.0.1:9200' and not file:
+            host = environ.get("TEST_ES_SERVER")
+            file = environ.get("ES_CLIENT_FILE", None)  # Path to es_client YAML config
+            repo = environ.get("TEST_ES_REPO")
+            if repo == LOCALREPO and host == "https://127.0.0.1:9200" and not file:
                 pytest.skip(
-                    'Local Docker test does not work with this test',
+                    "Local Docker test does not work with this test",
                     allow_module_level=False,
                 )
 
     return _skip_localhost
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def ssprefix(cold, frozen):
     def _ssprefix(tier):
-        retval = ''  # hot or warm
-        if tier == 'cold':
+        retval = ""  # hot or warm
+        if tier == "cold":
             retval = cold
-        if tier == 'frozen':
+        if tier == "frozen":
             retval = frozen
         return retval
 
     return _ssprefix
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def template(namecore):
     """Return the name of the index template"""
     return f'{namecore("template")}-000001'
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def uniq():
     """Return a random uniq value"""
     return randomstr(length=8, lowercase=True)
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def write_index_name(last, idxmain, idxss, idxtail, rollable):
-    def _write_index_name(which=last, plan=None, tier: str = 'hot'):
+    def _write_index_name(which=last, plan=None, tier: str = "hot"):
         if not rollable(plan):
-            return ''
+            return ""
         prefix = idxss(tier, which, plan)
         main = idxmain(plan.type)
         suffix = idxtail(which)
-        return f'{prefix}{main}{suffix}'
+        return f"{prefix}{main}{suffix}"
 
     return _write_index_name
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def ymd():
-    return datetime.now(timezone.utc).strftime('%Y.%m.%d')
+    return datetime.now(timezone.utc).strftime("%Y.%m.%d")

--- a/tests/integration/test_cold.py
+++ b/tests/integration/test_cold.py
@@ -6,22 +6,22 @@ from . import TestAny
 class TestDataStream(TestAny):
     """TestDataStream"""
 
-    scenario = 'cold_ds'
+    scenario = "cold_ds"
 
 
 class TestIndices(TestAny):
     """TestIndices"""
 
-    scenario = 'cold'
+    scenario = "cold"
 
 
 class TestRolloverIndices(TestAny):
     """TestRolloverIndices"""
 
-    scenario = 'cold_rollover'
+    scenario = "cold_rollover"
 
 
 class TestRolloverIndicesILM(TestAny):
     """TestRolloverIndicesILM"""
 
-    scenario = 'cold_ilm'
+    scenario = "cold_ilm"

--- a/tests/integration/test_es_api.py
+++ b/tests/integration/test_es_api.py
@@ -8,17 +8,17 @@ from . import INDEX1, SETTINGS
 
 def test_delete(client):
     create_index(client, INDEX1, settings=SETTINGS)  # Use the helper function instead
-    assert delete(client, 'index', INDEX1)
+    assert delete(client, "index", INDEX1)
 
 
-@pytest.mark.parametrize('name,idxcfg', [(INDEX1, {})], indirect=True)
+@pytest.mark.parametrize("name,idxcfg", [(INDEX1, {})], indirect=True)
 def test_verify_false(client, create_idx):
     """Verify index deleted is actually deleted
 
     A False return value from verify() means the index still exists.
     """
     assert create_idx.name == INDEX1
-    assert not verify(client, 'index', INDEX1)
+    assert not verify(client, "index", INDEX1)
 
 
 def test_verify_true(client):
@@ -26,4 +26,4 @@ def test_verify_true(client):
 
     A True return value from verify() means the index was deleted.
     """
-    assert verify(client, 'index', INDEX1)
+    assert verify(client, "index", INDEX1)

--- a/tests/integration/test_frozen.py
+++ b/tests/integration/test_frozen.py
@@ -6,22 +6,22 @@ from . import TestAny
 class TestDataStream(TestAny):
     """TestDataStream"""
 
-    scenario = 'frozen_ds'
+    scenario = "frozen_ds"
 
 
 class TestIndices(TestAny):
     """TestIndices"""
 
-    scenario = 'frozen'
+    scenario = "frozen"
 
 
 class TestRolloverIndices(TestAny):
     """TestRolloverIndices"""
 
-    scenario = 'frozen_rollover'
+    scenario = "frozen_rollover"
 
 
 class TestRolloverIndicesILM(TestAny):
     """TestRolloverIndicesILM"""
 
-    scenario = 'frozen_ilm'
+    scenario = "frozen_ilm"

--- a/tests/integration/test_hot.py
+++ b/tests/integration/test_hot.py
@@ -6,16 +6,16 @@ from . import TestAny
 class TestDataStream(TestAny):
     """TestDataStream"""
 
-    scenario = 'hot_ds'
+    scenario = "hot_ds"
 
 
 class TestIndices(TestAny):
     """TestIndices"""
 
-    scenario = 'hot'
+    scenario = "hot"
 
 
 class TestRolloverIndices(TestAny):
     """TestRolloverIndices"""
 
-    scenario = 'hot_rollover'
+    scenario = "hot_rollover"

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,30 +2,30 @@
 
 import typing as t
 
-ALIAS: str = 'test-alias'
+ALIAS: str = "test-alias"
 """Default alias name for testing."""
 
-INDEX1: str = 'index1'
+INDEX1: str = "index1"
 """Default index name for testing."""
 
-INDEX2: str = 'index2'
+INDEX2: str = "index2"
 """Additional index name for testing."""
 
 INDICES: t.Sequence[str] = [INDEX1, INDEX2]
 """Default index list for testing."""
 
-REPO: str = 'repo'
+REPO: str = "repo"
 """Default snapshot repository for testing."""
 
-TIERS: t.Sequence[str] = ['hot', 'warm', 'cold', 'frozen', 'delete']
+TIERS: t.Sequence[str] = ["hot", "warm", "cold", "frozen", "delete"]
 """Default ILM tiers for testing."""
 
 TREPO: t.Dict[str, t.Union[str, None]] = {
-    'hot': None,
-    'warm': None,
-    'cold': REPO,
-    'frozen': REPO,
-    'delete': None,
+    "hot": None,
+    "warm": None,
+    "cold": REPO,
+    "frozen": REPO,
+    "delete": None,
 }
 """Default ILM tiers and their corresponding repositories for testing."""
 
@@ -33,10 +33,10 @@ TREPO: t.Dict[str, t.Union[str, None]] = {
 def my_retval(kind, kwargs) -> t.Any:
     """Function to return all kinds of return values"""
     retval = None
-    if kind == 'alias_body':
+    if kind == "alias_body":
         retval = {
-            'name': kwargs.get('alias', ALIAS),
-            'indices': kwargs.get('indices', INDICES),
+            "name": kwargs.get("alias", ALIAS),
+            "indices": kwargs.get("indices", INDICES),
         }
     return retval
 
@@ -46,7 +46,7 @@ def forcemerge(
 ) -> t.Union[t.Dict[str, t.Dict[str, str]], None]:
     """Return forcemerge action."""
     if fm:
-        return {'forcemerge': {'max_num_segments': mns}}
+        return {"forcemerge": {"max_num_segments": mns}}
     return {}
 
 
@@ -56,9 +56,9 @@ def searchable(
     """Return searchable snapshot action."""
     if repository:
         return {
-            'searchable_snapshot': {
-                'snapshot_repository': repository,
-                'force_merge_index': fm,
+            "searchable_snapshot": {
+                "snapshot_repository": repository,
+                "force_merge_index": fm,
             }
         }
     return {}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,42 +28,42 @@ logger = logging.getLogger(__name__)
 debug.level = 5  # Set the debug level to 5 for all tests
 
 FMAP: t.Dict[str, t.Dict] = {
-    'hot': ilmhot(),
-    'warm': ilmwarm(),
-    'cold': ilmcold(),
-    'frozen': ilmfrozen(),
-    'delete': ilmdelete(),
+    "hot": ilmhot(),
+    "warm": ilmwarm(),
+    "cold": ilmcold(),
+    "frozen": ilmfrozen(),
+    "delete": ilmdelete(),
 }
 """Default ILM phase map for testing."""
 
 RESOLVER: t.Dict[str, t.Sequence] = {
-    'indices': [{'name': INDEX1}],
-    'aliases': [],
-    'data_streams': [],
+    "indices": [{"name": INDEX1}],
+    "aliases": [],
+    "data_streams": [],
 }
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def alias(request):
     return request.param
 
 
 @pytest.fixture
 def alias_body_params(alias, idx_list):
-    return {'name': alias, 'indices': idx_list}
+    return {"name": alias, "indices": idx_list}
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def alias_body():
-    return {'name': ALIAS, 'indices': INDICES}
+    return {"name": ALIAS, "indices": INDICES}
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def alias_cls(client, alias):
     return Alias(client=client, name=alias)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def client():
     """Return a mock Elasticsearch client."""
     return MagicMock()
@@ -79,7 +79,7 @@ def dt(request):
 def tz(request):
     return (
         datetime.timezone.utc
-        if request.param == 'UTC'
+        if request.param == "UTC"
         else datetime.timezone(datetime.timedelta(hours=request.param))
     )
 
@@ -118,7 +118,7 @@ def logmsg(request) -> str:
 
 @pytest.fixture
 def meta():
-    return ApiResponseMeta(200, '1.1', {}, 0.01, None)
+    return ApiResponseMeta(200, "1.1", {}, 0.01, None)
 
 
 @pytest.fixture()
@@ -130,7 +130,7 @@ def mock_datetime_now(monkeypatch, fake_now):
 
 @pytest.fixture
 def notfound(meta):
-    return NotFoundError('error', meta, 'error')
+    return NotFoundError("error", meta, "error")
 
 
 @pytest.fixture
@@ -158,20 +158,20 @@ def retval(request):
 def settings():
     """Return the PlanBuilder test settings."""
     return {
-        'type': 'indices',
-        'prefix': 'es-testbed',
-        'rollover_alias': False,
-        'uniq': 'my-unique-str',
-        'repository': 'test-repo',
-        'ilm': {
-            'enabled': False,
-            'phases': ['hot', 'delete'],
-            'readonly': 'PHASE',
-            'forcemerge': False,
-            'max_num_segments': 1,
-            'policy': {},
+        "type": "indices",
+        "prefix": "es-testbed",
+        "rollover_alias": False,
+        "uniq": "my-unique-str",
+        "repository": "test-repo",
+        "ilm": {
+            "enabled": False,
+            "phases": ["hot", "delete"],
+            "readonly": "PHASE",
+            "forcemerge": False,
+            "max_num_segments": 1,
+            "policy": {},
         },
-        'index_buildlist': [],
+        "index_buildlist": [],
     }
 
 
@@ -184,7 +184,7 @@ def tier(request) -> str:
 def tiered_debug(request) -> int:
     """Fixture to set the tiered debug level for tests"""
     retval = int(request.param)
-    logger.debug(f'Tiered debug level set to {retval}')
+    logger.debug(f"Tiered debug level set to {retval}")
     if not 1 <= retval <= 5:
         retval = 1
     return retval
@@ -193,12 +193,12 @@ def tiered_debug(request) -> int:
 # Fixture to create a basic IlmTracker instance with mocked dependencies
 @pytest.fixture
 def tracker(client):
-    with patch('es_testbed.ilm.resolver', return_value=RESOLVER), patch(
-        'es_testbed.ilm.ilm_explain',
-        return_value={'phase': 'hot', 'action': 'complete', 'step': 'complete'},
+    with patch("es_testbed.ilm.resolver", return_value=RESOLVER), patch(
+        "es_testbed.ilm.ilm_explain",
+        return_value={"phase": "hot", "action": "complete", "step": "complete"},
     ), patch(
-        'es_testbed.ilm.get_ilm_phases',
-        return_value={'hot': {}, 'warm': {}, 'delete': {}},
+        "es_testbed.ilm.get_ilm_phases",
+        return_value={"hot": {}, "warm": {}, "delete": {}},
     ):
         return IlmTracker(client, INDEX1)
 
@@ -207,9 +207,9 @@ def tracker(client):
 def tracker_adv(tracker):
     _ = tracker
     _._explain = Mock(phase=None)  # Mock the phase attribute
-    with patch('es_testbed.ilm.IlmTracker.next_phase', return_value=None), patch(
-        'es_testbed.ilm.IlmTracker.next_step',
-        return_value={'phase': 'mock_phase', 'action': 'mock_action'},
+    with patch("es_testbed.ilm.IlmTracker.next_phase", return_value=None), patch(
+        "es_testbed.ilm.IlmTracker.next_step",
+        return_value={"phase": "mock_phase", "action": "mock_action"},
     ):
         return _
 
@@ -220,22 +220,22 @@ def plan_builder(settings):
     return PlanBuilder(settings=settings, autobuild=False)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def repo_val():
     """Return the snapshot repository."""
     return REPO
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def testbed(client):
     """Return a TestBed instance."""
     _ = TestBed(
         client=client,
-        builtin='searchable_test',
-        path='path',
-        ref='ref',
-        url='url',
-        scenario='hot',
+        builtin="searchable_test",
+        path="path",
+        ref="ref",
+        url="url",
+        scenario="hot",
     )
     _.plan = MagicMock()
     return _
@@ -244,39 +244,39 @@ def testbed(client):
 @pytest.fixture
 def testbed_fodder(testbed):
     """Return a TestBed instance for testing the _erase_all method."""
-    testbed.plan.repository = 'test-repo'
-    testbed.plan.prefix = 'test-prefix'
-    testbed.plan.uniq = 'test-uniq'
+    testbed.plan.repository = "test-repo"
+    testbed.plan.prefix = "test-prefix"
+    testbed.plan.uniq = "test-uniq"
     return testbed
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def tiers():
     """Return the ILM tiers."""
     return TIERS
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def trepo():
     """Return the ILM tiers and their corresponding repositories."""
     return TREPO
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def tiertestval():
     """Return the ILM policy for a given tier."""
 
     def _tiertestval(tier: str, repo: str = None, fm: bool = False, mns: int = 1):
         retval = {tier: FMAP[tier]}
-        retval[tier]['actions'].update(searchable(repository=repo, fm=fm))
-        kwargs = {'fm': fm, 'mns': mns} if tier in ['hot', 'warm'] else {}
-        retval[tier]['actions'].update(forcemerge(**kwargs))
+        retval[tier]["actions"].update(searchable(repository=repo, fm=fm))
+        kwargs = {"fm": fm, "mns": mns} if tier in ["hot", "warm"] else {}
+        retval[tier]["actions"].update(forcemerge(**kwargs))
         return retval
 
     return _tiertestval
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def builtphase():
     """Return the built ILM phase."""
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -18,67 +18,67 @@ def test_init(testbed):
 
 def test_init_no_preset():
     """Test TestBed initialization without a preset."""
-    with patch('es_testbed._base.process_preset', return_value=(None, None)):
-        with pytest.raises(ValueError, match='Must define a preset'):
+    with patch("es_testbed._base.process_preset", return_value=(None, None)):
+        with pytest.raises(ValueError, match="Must define a preset"):
             TestBed(
                 client=MagicMock(),
-                builtin='searchable_test',
-                path='path',
-                ref='ref',
-                url='url',
-                scenario='hot',
+                builtin="searchable_test",
+                path="path",
+                ref="ref",
+                url="url",
+                scenario="hot",
             )
 
 
 def test_init_import_error():
     """Test TestBed initialization with an import error."""
-    with patch('es_testbed._base.process_preset', return_value=('modpath', None)):
-        with patch('es_testbed._base.import_module', side_effect=ImportError):
+    with patch("es_testbed._base.process_preset", return_value=("modpath", None)):
+        with patch("es_testbed._base.import_module", side_effect=ImportError):
             with pytest.raises(ImportError):
                 TestBed(
                     client=MagicMock(),
-                    builtin='searchable_test',
-                    path='path',
-                    ref='ref',
-                    url='url',
-                    scenario='hot',
+                    builtin="searchable_test",
+                    path="path",
+                    ref="ref",
+                    url="url",
+                    scenario="hot",
                 )
 
 
 def test_init_import_process_preset_tmpdir(testbed):
     """Test TestBed initialization with a tmpdir."""
-    expected = '/tmp/dir'
+    expected = "/tmp/dir"
     with patch(
-        'es_testbed._base.process_preset',
-        return_value=('es_testbed.presets.searchable_test', expected),
+        "es_testbed._base.process_preset",
+        return_value=("es_testbed.presets.searchable_test", expected),
     ):
         testbed = TestBed(
             client=MagicMock(),
-            builtin='searchable_test',
-            path='some/path',
-            ref='main',
-            url='https://github.com/repo.git',
+            builtin="searchable_test",
+            path="some/path",
+            ref="main",
+            url="https://github.com/repo.git",
         )
         # pylint: disable=E1136
-        assert getattr(testbed, 'settings')['tmpdir'] == expected
+        assert getattr(testbed, "settings")["tmpdir"] == expected
 
 
 def test_erase(testbed):
     """Test erase method."""
-    with patch('es_testbed._base.delete', return_value=True):
-        assert testbed._erase('index', ['test-index']) is True
+    with patch("es_testbed._base.delete", return_value=True):
+        assert testbed._erase("index", ["test-index"]) is True
 
 
 def test_erase_ilm(testbed):
     """Test erase method with ILM."""
-    with patch('es_testbed._base.delete', return_value=True):
-        assert testbed._erase('ilm', ['test-ilm']) is True
+    with patch("es_testbed._base.delete", return_value=True):
+        assert testbed._erase("ilm", ["test-ilm"]) is True
 
 
 def test_erase_failure(testbed):
     """Test erase method failure."""
-    with patch('es_testbed._base.delete', return_value=False):
-        assert testbed._erase('index', ['test-index']) is False
+    with patch("es_testbed._base.delete", return_value=False):
+        assert testbed._erase("index", ["test-index"]) is False
 
 
 # def test_erase_all(testbed):
@@ -91,23 +91,23 @@ def test_erase_failure(testbed):
 
 def test_erase_all(testbed_fodder):
     """Test _erase_all generator for each kind with multiple entities"""
-    with patch('es_testbed._base.get', return_value=['entity1', 'entity2']) as mock_get:
+    with patch("es_testbed._base.get", return_value=["entity1", "entity2"]) as mock_get:
         generator = testbed_fodder._erase_all()
         items = list(generator)
         assert len(items) == 6
         for kind, entities in items:
             assert kind in [
-                'index',
-                'data_stream',
-                'snapshot',
-                'template',
-                'component',
-                'ilm',
+                "index",
+                "data_stream",
+                "snapshot",
+                "template",
+                "component",
+                "ilm",
             ]
-            assert entities == ['entity1', 'entity2']
+            assert entities == ["entity1", "entity2"]
             pattern = (
-                f'*{testbed_fodder.plan.prefix}-{NAMEMAPPER[kind]}-'
-                f'{testbed_fodder.plan.uniq}*'
+                f"*{testbed_fodder.plan.prefix}-{NAMEMAPPER[kind]}-"
+                f"{testbed_fodder.plan.uniq}*"
             )
             mock_get.assert_any_call(
                 testbed_fodder.client,
@@ -123,17 +123,17 @@ def test_erase_all_no_repository(testbed_fodder):
     with multiple entities
     """
     testbed_fodder.plan.repository = None
-    with patch('es_testbed._base.get', return_value=['entity1', 'entity2']) as mock_get:
-        with patch('es_testbed._base.debug.lv4') as mock_debug:
+    with patch("es_testbed._base.get", return_value=["entity1", "entity2"]) as mock_get:
+        with patch("es_testbed._base.debug.lv4") as mock_debug:
             generator = testbed_fodder._erase_all()
             items = list(generator)
             assert len(items) == 5  # 'snapshot' should be skipped
             for kind, entities in items:
-                assert kind in ['index', 'data_stream', 'template', 'component', 'ilm']
-                assert entities == ['entity1', 'entity2']
+                assert kind in ["index", "data_stream", "template", "component", "ilm"]
+                assert entities == ["entity1", "entity2"]
                 pattern = (
-                    f'*{testbed_fodder.plan.prefix}-{NAMEMAPPER[kind]}-'
-                    f'{testbed_fodder.plan.uniq}*'
+                    f"*{testbed_fodder.plan.prefix}-{NAMEMAPPER[kind]}-"
+                    f"{testbed_fodder.plan.uniq}*"
                 )
                 mock_get.assert_any_call(
                     testbed_fodder.client,
@@ -142,19 +142,19 @@ def test_erase_all_no_repository(testbed_fodder):
                     repository=testbed_fodder.plan.repository,
                 )
             # assert 'No repository, no snapshots.' in caplog.text
-            mock_debug.assert_called_with('No repository, no snapshots.')
+            mock_debug.assert_called_with("No repository, no snapshots.")
 
 
 def test_while(testbed):
     """Test while method."""
-    with patch('es_testbed._base.delete', return_value=True):
-        assert testbed._while('index', 'test-index') is True
+    with patch("es_testbed._base.delete", return_value=True):
+        assert testbed._while("index", "test-index") is True
 
 
 def test_while_failure(testbed):
     """Test while method failure."""
-    with patch('es_testbed._base.delete', side_effect=ResultNotExpected('error')):
-        assert testbed._while('index', 'test-index') is False
+    with patch("es_testbed._base.delete", side_effect=ResultNotExpected("error")):
+        assert testbed._while("index", "test-index") is False
 
 
 def test_get_ilm_polling_produces_debug_log(testbed, caplog):
@@ -162,7 +162,7 @@ def test_get_ilm_polling_produces_debug_log(testbed, caplog):
     caplog.set_level(logging.DEBUG)
     with debug.change_level(5):
         testbed.get_ilm_polling()
-    assert 'Cluster settings' in caplog.text
+    assert "Cluster settings" in caplog.text
 
 
 def test_get_ilm_polling_exception(testbed, caplog):
@@ -172,45 +172,45 @@ def test_get_ilm_polling_exception(testbed, caplog):
     """
     caplog.set_level(40)  # CRITICAL
     with patch.object(
-        testbed.client.cluster, 'get_settings', side_effect=Exception('error')
+        testbed.client.cluster, "get_settings", side_effect=Exception("error")
     ):
-        with pytest.raises(Exception, match='error'):
+        with pytest.raises(Exception, match="error"):
             testbed.get_ilm_polling()
-            assert 'Unable to get persistent cluster settings' in caplog.text
-            assert 'This could be permissions, or something larger' in caplog.text
-            assert 'Exiting.' in caplog.text
+            assert "Unable to get persistent cluster settings" in caplog.text
+            assert "This could be permissions, or something larger" in caplog.text
+            assert "Exiting." in caplog.text
 
 
 def test_get_ilm_polling_1s(testbed):
     """Test ilm_polling method when"""
-    assert testbed.ilm_polling('1s') == {'indices.lifecycle.poll_interval': '1s'}
+    assert testbed.ilm_polling("1s") == {"indices.lifecycle.poll_interval": "1s"}
 
 
 def test_get_ilm_polling_already_set(testbed):
     """Test get_ilm_polling method when ILM polling is already set."""
     with patch.object(
         testbed.client.cluster,
-        'get_settings',
+        "get_settings",
         return_value={
-            'persistent': {'indices': {'lifecycle': {'poll_interval': '1s'}}}
+            "persistent": {"indices": {"lifecycle": {"poll_interval": "1s"}}}
         },
     ):
-        with patch('es_testbed._base.logger.warning') as mock_warning:
+        with patch("es_testbed._base.logger.warning") as mock_warning:
             testbed.get_ilm_polling()
             assert testbed.plan.ilm_polling_interval is None
             mock_warning.assert_called_once_with(
-                'ILM polling already set at 1s. A previous run most likely did not '
-                'tear down properly. Resetting to null after this run'
+                "ILM polling already set at 1s. A previous run most likely did not "
+                "tear down properly. Resetting to null after this run"
             )
 
 
 def test_setup(testbed):
     """Test setup method."""
     with patch(
-        'es_testbed._base.PlanBuilder', return_value=MagicMock(plan=MagicMock())
+        "es_testbed._base.PlanBuilder", return_value=MagicMock(plan=MagicMock())
     ):
-        with patch('es_testbed._base.TestBed.get_ilm_polling'):
-            with patch('es_testbed._base.TestBed.setup_entitymgrs'):
+        with patch("es_testbed._base.TestBed.get_ilm_polling"):
+            with patch("es_testbed._base.TestBed.setup_entitymgrs"):
                 testbed.setup()
                 assert testbed.plan is not None
 
@@ -218,14 +218,14 @@ def test_setup(testbed):
 def test_teardown(testbed):
     """Test teardown method."""
     with patch(
-        'es_testbed._base.TestBed._erase_all',
-        return_value=[('index', ['test-index'])],
+        "es_testbed._base.TestBed._erase_all",
+        return_value=[("index", ["test-index"])],
     ):
-        with patch('es_testbed._base.TestBed._erase', return_value=True):
-            with patch('es_testbed._base.rmtree'):
+        with patch("es_testbed._base.TestBed._erase", return_value=True):
+            with patch("es_testbed._base.rmtree"):
                 with patch(
-                    'es_testbed._base.TestBed.ilm_polling',
-                    return_value={'indices.lifecycle.poll_interval': '1s'},
+                    "es_testbed._base.TestBed.ilm_polling",
+                    return_value={"indices.lifecycle.poll_interval": "1s"},
                 ):
                     testbed.teardown()
                     assert testbed.plan.cleanup is True
@@ -234,14 +234,14 @@ def test_teardown(testbed):
 def test_teardown_not_successful(testbed):
     """Test teardown method when cleanup is not successful."""
     with patch(
-        'es_testbed._base.TestBed._erase_all',
-        return_value=[('index', ['test-index'])],
+        "es_testbed._base.TestBed._erase_all",
+        return_value=[("index", ["test-index"])],
     ):
-        with patch('es_testbed._base.TestBed._erase', return_value=False):
-            with patch('es_testbed._base.rmtree'):
+        with patch("es_testbed._base.TestBed._erase", return_value=False):
+            with patch("es_testbed._base.rmtree"):
                 with patch(
-                    'es_testbed._base.TestBed.ilm_polling',
-                    return_value={'indices.lifecycle.poll_interval': '1s'},
+                    "es_testbed._base.TestBed.ilm_polling",
+                    return_value={"indices.lifecycle.poll_interval": "1s"},
                 ):
                     testbed.teardown()
                     assert testbed.plan.cleanup is False

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -8,7 +8,7 @@ from es_testbed.defaults import ilmcold, ilmwarm, ilm_force_merge, ilm_phase
 @pytest.fixture
 def forcemerge():
     def _forcemerge(mns: int = 1):
-        return {'forcemerge': {'max_num_segments': mns}}
+        return {"forcemerge": {"max_num_segments": mns}}
 
     return _forcemerge
 
@@ -23,10 +23,10 @@ def test_default_ilm_fm_mns(forcemerge):
 
 
 def test_default_ilm_warm():
-    tier = 'warm'
+    tier = "warm"
     assert ilm_phase(tier) == {tier: ilmwarm()}
 
 
 def test_default_ilm_cold():
-    tier = 'cold'
+    tier = "cold"
     assert ilm_phase(tier) == {tier: ilmcold()}

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -14,48 +14,48 @@ from es_testbed.exceptions import TestbedFailure
 from . import ALIAS, INDEX1, INDICES, my_retval
 
 
-ALIAS_FIXT: str = 'alias,idx_list,retval,expected'
+ALIAS_FIXT: str = "alias,idx_list,retval,expected"
 """CSV string of pytest.mark.parametrize fixtures for Alias tests."""
 
 ALIAS_PARAMS: dict = {
-    'default_match': (ALIAS, INDICES, my_retval('alias_body', {}), True),
-    'src_idx_nomatch': (
+    "default_match": (ALIAS, INDICES, my_retval("alias_body", {}), True),
+    "src_idx_nomatch": (
         ALIAS,
-        ['missing1', 'missing2'],
-        my_retval('alias_body', {}),
+        ["missing1", "missing2"],
+        my_retval("alias_body", {}),
         False,
     ),
-    'src_alias_nomatch': ('nomatch', INDICES, my_retval('alias_body', {}), False),
-    'retval_alias_nomatch': (
+    "src_alias_nomatch": ("nomatch", INDICES, my_retval("alias_body", {}), False),
+    "retval_alias_nomatch": (
         ALIAS,
         INDICES,
-        my_retval('alias_body', {'alias': 'nomatch'}),
+        my_retval("alias_body", {"alias": "nomatch"}),
         False,
     ),
-    'retval_idx_nomatch': (
+    "retval_idx_nomatch": (
         ALIAS,
         INDICES,
-        my_retval('alias_body', {'indices': ['no1', 'no2']}),
+        my_retval("alias_body", {"indices": ["no1", "no2"]}),
         False,
     ),
 }
 """Test parameters for Alias tests"""
 
-INDEX_FIXT: str = 'phase,phases,expected,logmsg'
+INDEX_FIXT: str = "phase,phases,expected,logmsg"
 """CSV string of pytest.mark.parametrize fixtures for Index tests."""
 
 INDEX_PARAMS: dict = {
-    'stay-hot': (
-        'hot',
-        ['hot', 'delete'],
-        'hot',
+    "stay-hot": (
+        "hot",
+        ["hot", "delete"],
+        "hot",
         f'ILM Policy for "{INDEX1}" has no cold/frozen phases',
     ),
-    'hot-cold-frozen2cold': ('hot', ['hot', 'cold', 'frozen'], 'cold', ''),
-    'hot2cold': ('hot', ['hot', 'cold'], 'cold', ''),
-    'hot2frozen': ('hot', ['hot', 'frozen'], 'frozen', ''),
-    'hot-cold-frozen,cold2frozen': ('cold', ['hot', 'cold', 'frozen'], 'frozen', ''),
-    'hot-cold-frozen,stay-frozen': ('frozen', ['hot', 'cold', 'frozen'], 'frozen', ''),
+    "hot-cold-frozen2cold": ("hot", ["hot", "cold", "frozen"], "cold", ""),
+    "hot2cold": ("hot", ["hot", "cold"], "cold", ""),
+    "hot2frozen": ("hot", ["hot", "frozen"], "frozen", ""),
+    "hot-cold-frozen,cold2frozen": ("cold", ["hot", "cold", "frozen"], "frozen", ""),
+    "hot-cold-frozen,stay-frozen": ("frozen", ["hot", "cold", "frozen"], "frozen", ""),
 }
 """Test parameters for Index tests"""
 
@@ -77,15 +77,15 @@ def test_verify_method(alias, alias_cls, expected, idx_list, retval, caplog):
     caplog.set_level(logging.DEBUG)
     with debug.change_level(5):
         with patch(
-            'es_testbed.entities.alias.resolver',
-            return_value={'aliases': [retval]},
+            "es_testbed.entities.alias.resolver",
+            return_value={"aliases": [retval]},
         ):
             result = alias_cls.verify(idx_list)
             assert result is expected
             if result:
-                assert 'Confirm list index position [0] match of alias' in caplog.text
+                assert "Confirm list index position [0] match of alias" in caplog.text
                 assert (
-                    f'Confirm match of indices backed by alias {alias}' in caplog.text
+                    f"Confirm match of indices backed by alias {alias}" in caplog.text
                 )
 
 
@@ -99,10 +99,10 @@ def test_get_target(index_cls, phase, phases, expected, logmsg, caplog):
         index_cls.ilm_tracker.policy_phases = phases
         index_cls.ilm_tracker.explain.phase = phase
         index_cls.ilm_tracker.pname.side_effect = lambda x: {
-            'hot': 1,
-            'warm': 2,
-            'cold': 3,
-            'frozen': 4,
+            "hot": 1,
+            "warm": 2,
+            "cold": 3,
+            "frozen": 4,
         }[x]
         target = index_cls._get_target
         assert target == expected
@@ -111,42 +111,42 @@ def test_get_target(index_cls, phase, phases, expected, logmsg, caplog):
 
 
 def test_phase_tuple(index_cls):
-    index_cls.ilm_tracker.explain.phase = 'hot'
-    index_cls.ilm_tracker.policy_phases = ['hot', 'cold', 'frozen']
+    index_cls.ilm_tracker.explain.phase = "hot"
+    index_cls.ilm_tracker.policy_phases = ["hot", "cold", "frozen"]
     index_cls.ilm_tracker.pname.side_effect = lambda x: {
-        'hot': 1,
-        'cold': 2,
-        'frozen': 3,
+        "hot": 1,
+        "cold": 2,
+        "frozen": 3,
     }[x]
-    assert index_cls.phase_tuple == ('hot', 'cold')
+    assert index_cls.phase_tuple == ("hot", "cold")
 
 
 def test_add_snap_step(index_cls, caplog):
     caplog.set_level(logging.DEBUG)
     with debug.change_level(5):
         index_cls.snapmgr = MagicMock()
-        snap = 'snapshot1'
-        with patch('es_testbed.entities.index.snapshot_name', return_value=snap):
+        snap = "snapshot1"
+        with patch("es_testbed.entities.index.snapshot_name", return_value=snap):
             index_cls._add_snap_step()
-            assert 'Getting snapshot name for tracking...' in caplog.text
-            assert f'Snapshot {snap} backs {INDEX1}' in caplog.text
+            assert "Getting snapshot name for tracking..." in caplog.text
+            assert f"Snapshot {snap} backs {INDEX1}" in caplog.text
             index_cls.snapmgr.add_existing.assert_called_once_with(snap)
 
 
 def test_ilm_step(index_cls, caplog):
     caplog.set_level(logging.DEBUG)
-    phase, action, name = ('hot', 'complete', 'step1')
+    phase, action, name = ("hot", "complete", "step1")
     index_cls.ilm_tracker.explain.phase = phase
     index_cls.ilm_tracker.explain.action = action
     index_cls.ilm_tracker.explain.step = name
     index_cls.client.ilm.explain_lifecycle.return_value = {
-        "indices": {INDEX1: {'phase': phase, 'action': action, 'step': name}}
+        "indices": {INDEX1: {"phase": phase, "action": action, "step": name}}
     }
     with debug.change_level(5):
-        with patch('es_testbed.entities.index.IlmStep') as mock_ilm_step:
+        with patch("es_testbed.entities.index.IlmStep") as mock_ilm_step:
             mock_ilm_step_instance = mock_ilm_step.return_value
             index_cls._ilm_step()
-            assert f'DEBUG5 {INDEX1}: Current Step:' in caplog.text
+            assert f"DEBUG5 {INDEX1}: Current Step:" in caplog.text
             assert f"'phase': '{phase}'" in caplog.text
             assert f"'action': '{action}'" in caplog.text
             assert f"'name': '{name}'" in caplog.text
@@ -155,21 +155,21 @@ def test_ilm_step(index_cls, caplog):
 
 def test_ilm_step_failure(index_cls):
     index_cls.ilm_tracker = MagicMock()
-    phase, action, name = ('hot', 'complete', 'step1')
+    phase, action, name = ("hot", "complete", "step1")
     index_cls.ilm_tracker.explain.phase = phase
     index_cls.ilm_tracker.explain.action = action
     index_cls.ilm_tracker.explain.step = name
-    with patch('es_testbed.entities.index.logger.debug'):
-        with patch('es_testbed.entities.index.IlmStep') as mock_ilm_step:
+    with patch("es_testbed.entities.index.logger.debug"):
+        with patch("es_testbed.entities.index.IlmStep") as mock_ilm_step:
             mock_ilm_step_instance = mock_ilm_step.return_value
             with patch.object(
-                index_cls, '_wait_try', side_effect=TestbedFailure('testbed failure')
+                index_cls, "_wait_try", side_effect=TestbedFailure("testbed failure")
             ) as mock_wait_try:
-                with patch('es_testbed.entities.index.logger.error') as mock_error:
+                with patch("es_testbed.entities.index.logger.error") as mock_error:
                     with pytest.raises(TestbedFailure):
                         index_cls._ilm_step()
                         mock_wait_try.assert_any_call(mock_ilm_step_instance.wait)
-                        mock_error.assert_called_once_with('testbed failure')
+                        mock_error.assert_called_once_with("testbed failure")
 
 
 def test_wait_try_success(index_cls):
@@ -180,20 +180,20 @@ def test_wait_try_success(index_cls):
 
 def test_wait_try_es_wait_fatal(index_cls):
     func = MagicMock(
-        side_effect=EsWaitFatal('fatal error', elapsed=10, errors=['error1'])
+        side_effect=EsWaitFatal("fatal error", elapsed=10, errors=["error1"])
     )
-    with pytest.raises(TestbedFailure, match='fatal error. Elapsed time: 10. Errors:'):
+    with pytest.raises(TestbedFailure, match="fatal error. Elapsed time: 10. Errors:"):
         index_cls._wait_try(func)
 
 
 def test_wait_try_es_wait_timeout(index_cls):
-    func = MagicMock(side_effect=EsWaitTimeout('timeout error', 10.0, 10.0))
-    with pytest.raises(TestbedFailure, match='timeout error. Total elapsed time: 10.'):
+    func = MagicMock(side_effect=EsWaitTimeout("timeout error", 10.0, 10.0))
+    with pytest.raises(TestbedFailure, match="timeout error. Total elapsed time: 10."):
         index_cls._wait_try(func)
 
 
 def test_wait_try_general_exception(index_cls):
-    err = 'foo'
+    err = "foo"
     msg = f"General Exception caught: \nException('{err}')"
     func = MagicMock(side_effect=Exception(err))
     with pytest.raises(TestbedFailure) as exc:
@@ -205,64 +205,64 @@ def test_mounted_step(index_cls, caplog):
     caplog.set_level(logging.DEBUG)
     with debug.change_level(3):
         index_cls.ilm_tracker.advance = MagicMock()
-        new = 'new-index'
-        target = 'cold'
+        new = "new-index"
+        target = "cold"
         index_cls.client.ilm.explain_lifecycle.return_value = {
-            "indices": {new: {'phase': 'hot', 'action': 'complete', 'step': 'complete'}}
+            "indices": {new: {"phase": "hot", "action": "complete", "step": "complete"}}
         }
-        with patch('es_testbed.entities.index.mounted_name', return_value=new):
-            with patch('es_testbed.entities.index.Exists') as mock_exists:
+        with patch("es_testbed.entities.index.mounted_name", return_value=new):
+            with patch("es_testbed.entities.index.Exists") as mock_exists:
                 mock_exists_instance = mock_exists.return_value
                 index_cls._mounted_step(target)
                 index_cls.ilm_tracker.advance.assert_called_once_with(phase=target)
                 assert (
-                    f'Waiting for ILM phase change to complete. New index: {new}'
+                    f"Waiting for ILM phase change to complete. New index: {new}"
                     in caplog.text
                 )
                 mock_exists_instance.wait.assert_called_once()
                 assert (
                     f'Updating self.name from "{INDEX1}" to "{new}"...' in caplog.text
                 )
-                assert 'Waiting for the ILM steps to complete...' in caplog.text
+                assert "Waiting for the ILM steps to complete..." in caplog.text
                 assert f'Switching to track "{new}" as self.name...' in caplog.text
 
 
 def test_mounted_step_bad_request_error(index_cls):
-    meta = ApiResponseMeta(404, '1.1', {}, 0.01, None)
+    meta = ApiResponseMeta(404, "1.1", {}, 0.01, None)
     index_cls.ilm_tracker = MagicMock()
     index_cls.ilm_tracker.advance = MagicMock(
-        side_effect=BadRequestError('bad request', meta, 'bad request')
+        side_effect=BadRequestError("bad request", meta, "bad request")
     )
-    with pytest.raises(BadRequestError, match='bad request'):
-        index_cls._mounted_step('cold')
+    with pytest.raises(BadRequestError, match="bad request"):
+        index_cls._mounted_step("cold")
 
 
 def test_mounted_step_testbed_failure(index_cls):
-    new = 'new-index'
+    new = "new-index"
     index_cls.ilm_tracker = MagicMock()
     index_cls.ilm_tracker.advance = MagicMock()
-    with patch('es_testbed.entities.index.mounted_name', return_value=new):
-        with patch('es_testbed.entities.index.Exists') as mock_exists:
+    with patch("es_testbed.entities.index.mounted_name", return_value=new):
+        with patch("es_testbed.entities.index.Exists") as mock_exists:
             mock_exists_instance = mock_exists.return_value
-            with patch('es_testbed.entities.index.logger.debug'):
+            with patch("es_testbed.entities.index.logger.debug"):
                 with patch.object(
                     index_cls,
-                    '_wait_try',
-                    side_effect=TestbedFailure('testbed failure'),
+                    "_wait_try",
+                    side_effect=TestbedFailure("testbed failure"),
                 ) as mock_wait_try:
-                    with patch('es_testbed.entities.index.logger.error') as mock_error:
+                    with patch("es_testbed.entities.index.logger.error") as mock_error:
                         with pytest.raises(TestbedFailure):
-                            index_cls._mounted_step('cold')
+                            index_cls._mounted_step("cold")
                             mock_wait_try.assert_any_call(mock_exists_instance.wait)
-                            mock_error.assert_called_once_with('testbed failure')
+                            mock_error.assert_called_once_with("testbed failure")
 
 
 def test_manual_ss(index_cls):
     index_cls.snapmgr = MagicMock()
-    new = 'new-index'
-    target = 'cold'
-    scheme = {'target_tier': target}
-    with patch('es_testbed.entities.index.mounted_name', return_value=new):
+    new = "new-index"
+    target = "cold"
+    scheme = {"target_tier": target}
+    with patch("es_testbed.entities.index.mounted_name", return_value=new):
         index_cls.manual_ss(scheme)
         assert index_cls.name == new
 
@@ -271,8 +271,8 @@ def test_mount_ss_no_policy(index_cls, caplog):
     caplog.set_level(logging.DEBUG)
     with debug.change_level(3):
         index_cls.snapmgr = MagicMock()
-        scheme = {'target_tier': 'cold'}
-        with patch.object(index_cls, 'manual_ss') as mock_manual_ss:
+        scheme = {"target_tier": "cold"}
+        with patch.object(index_cls, "manual_ss") as mock_manual_ss:
             index_cls.mount_ss(scheme)
             assert f'No ILM policy for "{INDEX1}". Trying manual...' in caplog.text
             mock_manual_ss.assert_called_once_with(scheme)
@@ -281,8 +281,8 @@ def test_mount_ss_no_policy(index_cls, caplog):
 def test_mount_ss_write_index(index_cls, caplog):
     caplog.set_level(logging.DEBUG)
     with debug.change_level(5):
-        with patch('es_testbed.entities.Index.am_i_write_idx', return_value=True):
-            scheme = {'target_tier': 'cold'}
+        with patch("es_testbed.entities.Index.am_i_write_idx", return_value=True):
+            scheme = {"target_tier": "cold"}
             index_cls.mount_ss(scheme)
             assert (
                 f'"{INDEX1}" is the write_index. Cannot mount as searchable snapshot'
@@ -293,15 +293,15 @@ def test_mount_ss_write_index(index_cls, caplog):
 def test_mount_ss_phase_new(index_cls, caplog):
     caplog.set_level(logging.DEBUG)
     with debug.change_level(3):
-        curr, target = ('new', 'cold')
-        index_cls.policy_name = 'test-policy'
+        curr, target = ("new", "cold")
+        index_cls.policy_name = "test-policy"
         index_cls.ilm_tracker = MagicMock()
         index_cls.ilm_tracker.next_phase = target
         index_cls.ilm_tracker.explain.phase = curr
-        scheme = {'target_tier': target}
-        with patch('es_testbed.entities.index.IlmPhase') as mock_ilm_phase:
+        scheme = {"target_tier": target}
+        with patch("es_testbed.entities.index.IlmPhase") as mock_ilm_phase:
             mock_ilm_phase_instance = mock_ilm_phase.return_value
-            with patch.object(index_cls, '_wait_try') as mock_wait_try:
+            with patch.object(index_cls, "_wait_try") as mock_wait_try:
                 index_cls.mount_ss(scheme)
                 assert (
                     f'Our index is still in phase "{curr}"!. We need it to be in "{target}"'
@@ -312,13 +312,13 @@ def test_mount_ss_phase_new(index_cls, caplog):
 
 def test_mount_ss_phase_new_raises(index_cls, caplog):
     caplog.set_level(logging.DEBUG)
-    err = 'SPECIFIC ERROR'
-    curr, target = ('new', 'cold')
-    index_cls.policy_name = 'test-policy'
+    err = "SPECIFIC ERROR"
+    curr, target = ("new", "cold")
+    index_cls.policy_name = "test-policy"
     index_cls.ilm_tracker = MagicMock()
     index_cls.ilm_tracker.next_phase = target
     index_cls.ilm_tracker.explain.phase = curr
-    with patch.object(index_cls, '_wait_try', side_effect=TestbedFailure(err)):
+    with patch.object(index_cls, "_wait_try", side_effect=TestbedFailure(err)):
         with pytest.raises(TestbedFailure):
-            index_cls.mount_ss({'target_tier': target})
+            index_cls.mount_ss({"target_tier": target})
             assert err in caplog.text

--- a/tests/unit/test_es_api.py
+++ b/tests/unit/test_es_api.py
@@ -35,69 +35,69 @@ from es_testbed.exceptions import (
 
 
 def test_change_ds_success(client):
-    change_ds(client, actions='test-actions')
+    change_ds(client, actions="test-actions")
     client.indices.modify_data_stream.assert_called_once_with(
-        actions='test-actions', body=None
+        actions="test-actions", body=None
     )
 
 
 def test_change_ds_exception(client):
-    client.indices.modify_data_stream.side_effect = Exception('error')
+    client.indices.modify_data_stream.side_effect = Exception("error")
     with pytest.raises(ResultNotExpected):
-        change_ds(client, actions='test-actions')
+        change_ds(client, actions="test-actions")
 
 
 def test_get_write_index(client):
     client.indices.get_alias.return_value = {
-        'index1': {'aliases': {'test-alias': {'is_write_index': True}}},
-        'index2': {'aliases': {'test-alias': {'is_write_index': False}}},
+        "index1": {"aliases": {"test-alias": {"is_write_index": True}}},
+        "index2": {"aliases": {"test-alias": {"is_write_index": False}}},
     }
-    result = get_write_index(client, 'test-alias')
-    assert result == 'index1'
+    result = get_write_index(client, "test-alias")
+    assert result == "index1"
 
 
 def test_get_write_index_no_write_index(client):
     client.indices.get_alias.return_value = {
-        'index1': {'aliases': {'test-alias': {'is_write_index': False}}},
-        'index2': {'aliases': {'test-alias': {'is_write_index': False}}},
+        "index1": {"aliases": {"test-alias": {"is_write_index": False}}},
+        "index2": {"aliases": {"test-alias": {"is_write_index": False}}},
     }
-    result = get_write_index(client, 'test-alias')
+    result = get_write_index(client, "test-alias")
     assert result is None
 
 
 def test_resolver(client):
     client.indices.resolve_index.return_value = {
-        'indices': ['index1'],
-        'aliases': ['alias1'],
-        'data_streams': ['data_stream1'],
+        "indices": ["index1"],
+        "aliases": ["alias1"],
+        "data_streams": ["data_stream1"],
     }
-    result = resolver(client, 'test-name')
+    result = resolver(client, "test-name")
     assert result == {
-        'indices': ['index1'],
-        'aliases': ['alias1'],
-        'data_streams': ['data_stream1'],
+        "indices": ["index1"],
+        "aliases": ["alias1"],
+        "data_streams": ["data_stream1"],
     }
 
 
 def test_rollover(client):
-    rollover(client, 'test-alias')
+    rollover(client, "test-alias")
     client.indices.rollover.assert_called_once_with(
-        alias='test-alias', wait_for_active_shards='all'
+        alias="test-alias", wait_for_active_shards="all"
     )
 
 
 def test_ilm_move(client):
-    ilm_move(client, 'test-index', {'phase': 'hot'}, {'phase': 'cold'})
+    ilm_move(client, "test-index", {"phase": "hot"}, {"phase": "cold"})
     client.ilm.move_to_step.assert_called_once_with(
-        index='test-index', current_step={'phase': 'hot'}, next_step={'phase': 'cold'}
+        index="test-index", current_step={"phase": "hot"}, next_step={"phase": "cold"}
     )
 
 
 def test_ilm_move_exception(client, caplog):
     caplog.set_level(50)
-    client.ilm.move_to_step.side_effect = Exception('error')
+    client.ilm.move_to_step.side_effect = Exception("error")
     with pytest.raises(ResultNotExpected):
-        ilm_move(client, 'test-index', {'phase': 'hot'}, {'phase': 'cold'})
+        ilm_move(client, "test-index", {"phase": "hot"}, {"phase": "cold"})
         assert (
             "Unable to move index test-index to ILM next step: "
             "{'phase': 'cold'}" in caplog.text
@@ -105,98 +105,98 @@ def test_ilm_move_exception(client, caplog):
 
 
 def test_put_comp_tmpl(client):
-    with patch('es_testbed.es_api.wait_wrapper') as mock_wait_wrapper:
-        put_comp_tmpl(client, 'test-template', {'template': 'data'})
+    with patch("es_testbed.es_api.wait_wrapper") as mock_wait_wrapper:
+        put_comp_tmpl(client, "test-template", {"template": "data"})
         mock_wait_wrapper.assert_called_once()
 
 
 def test_put_idx_tmpl(client):
-    with patch('es_testbed.es_api.wait_wrapper') as mock_wait_wrapper:
-        put_idx_tmpl(client, 'test-template', ['pattern'], ['component'])
+    with patch("es_testbed.es_api.wait_wrapper") as mock_wait_wrapper:
+        put_idx_tmpl(client, "test-template", ["pattern"], ["component"])
         mock_wait_wrapper.assert_called_once()
 
 
 def test_put_ilm(client):
-    put_ilm(client, 'test-policy', {'policy': 'data'})
+    put_ilm(client, "test-policy", {"policy": "data"})
     client.ilm.put_lifecycle.assert_called_once_with(
-        name='test-policy', policy={'policy': 'data'}
+        name="test-policy", policy={"policy": "data"}
     )
 
 
 def test_put_ilm_exception(client):
-    client.ilm.put_lifecycle.side_effect = Exception('error')
+    client.ilm.put_lifecycle.side_effect = Exception("error")
     with pytest.raises(TestbedFailure):
-        put_ilm(client, 'test-policy', {'policy': 'data'})
+        put_ilm(client, "test-policy", {"policy": "data"})
 
 
 def test_snapshot_name(client):
     client.indices.get.return_value = {
-        'test-index': {
-            'settings': {
-                'index': {'store': {'snapshot': {'snapshot_name': 'snapshot1'}}}
+        "test-index": {
+            "settings": {
+                "index": {"store": {"snapshot": {"snapshot_name": "snapshot1"}}}
             }
         }
     }
-    with patch('es_testbed.es_api.exists', return_value=True):
-        result = snapshot_name(client, 'test-index')
-        assert result == 'snapshot1'
+    with patch("es_testbed.es_api.exists", return_value=True):
+        result = snapshot_name(client, "test-index")
+        assert result == "snapshot1"
 
 
 def test_snapshot_name_no_snapshot(client):
-    client.indices.get.return_value = {'test-index': {'settings': {'index': {}}}}
-    with patch('es_testbed.es_api.exists', return_value=True):
-        with patch('es_testbed.es_api.logger.error') as mock_error:
-            result = snapshot_name(client, 'test-index')
+    client.indices.get.return_value = {"test-index": {"settings": {"index": {}}}}
+    with patch("es_testbed.es_api.exists", return_value=True):
+        with patch("es_testbed.es_api.logger.error") as mock_error:
+            result = snapshot_name(client, "test-index")
             assert result is None
             mock_error.assert_called_once_with(
-                'test-index is not a searchable snapshot'
+                "test-index is not a searchable snapshot"
             )
 
 
 def test_get_aliases_keyerror(client):
-    name = 'test-index'
+    name = "test-index"
     client.indices.get.return_value = {name: {}}
     assert get_aliases(client, name) is None
 
 
 def test_get_backing_indices_raises(client):
-    name = 'a'
+    name = "a"
     with patch(
-        'es_testbed.es_api.resolver', return_value={'data_streams': ['a', 'aa']}
+        "es_testbed.es_api.resolver", return_value={"data_streams": ["a", "aa"]}
     ):
         with pytest.raises(ResultNotExpected) as err:
             get_backing_indices(client, name)
             assert (
-                f'Expected only a single data_stream matching {name}'
+                f"Expected only a single data_stream matching {name}"
                 in err.value.args[0]
             )
 
 
 def test_get_ilm_raises(client, caplog):
     caplog.set_level(50)
-    client.ilm.get_lifecycle.side_effect = Exception('error')
-    pattern = 'test-index'
+    client.ilm.get_lifecycle.side_effect = Exception("error")
+    pattern = "test-index"
     with pytest.raises(ResultNotExpected):
         get_ilm(client, pattern)
-        assert f'Unable to get ILM lifecycle matching {pattern}' in caplog.text
+        assert f"Unable to get ILM lifecycle matching {pattern}" in caplog.text
 
 
 def test_get_ilm_phases_raises(client, caplog):
     caplog.set_level(50)
-    name = 'test-index'
-    with patch('es_testbed.es_api.get_ilm', return_value={'not': 'found'}):
+    name = "test-index"
+    with patch("es_testbed.es_api.get_ilm", return_value={"not": "found"}):
         with pytest.raises(ResultNotExpected):
             get_ilm_phases(client, name)
-            assert f'Unable to get ILM lifecycle named {name}.' in caplog.text
+            assert f"Unable to get ILM lifecycle named {name}." in caplog.text
 
 
 class TestWaitWrapper:
 
     def test_wait_wrapper_success(self, client):
         wait_cls = MagicMock()
-        wait_kwargs = {'name': 'test-name', 'kind': 'index', 'pause': 1}
+        wait_kwargs = {"name": "test-name", "kind": "index", "pause": 1}
         func = MagicMock()
-        f_kwargs = {'name': 'test-name'}
+        f_kwargs = {"name": "test-name"}
         wait_wrapper(client, wait_cls, wait_kwargs, func, f_kwargs)
         func.assert_called_once_with(**f_kwargs)
         wait_cls.assert_called_once_with(client, **wait_kwargs)
@@ -204,11 +204,11 @@ class TestWaitWrapper:
 
     def test_wait_wrapper_es_wait_fatal(self, client):
         wait_cls = MagicMock()
-        wait_kwargs = {'name': 'test-name', 'kind': 'index', 'pause': 1}
+        wait_kwargs = {"name": "test-name", "kind": "index", "pause": 1}
         func = MagicMock()
-        f_kwargs = {'name': 'test-name'}
+        f_kwargs = {"name": "test-name"}
         wait_cls.return_value.wait.side_effect = EsWaitFatal(
-            'fatal error', elapsed=10, errors=['error1']
+            "fatal error", elapsed=10, errors=["error1"]
         )
         with pytest.raises(
             TestbedFailure, match="fatal error. Elapsed time: 10. Errors:"
@@ -217,35 +217,35 @@ class TestWaitWrapper:
 
     def test_wait_wrapper_es_wait_timeout(self, client):
         wait_cls = MagicMock()
-        wait_kwargs = {'name': 'test-name', 'kind': 'index', 'pause': 1}
+        wait_kwargs = {"name": "test-name", "kind": "index", "pause": 1}
         func = MagicMock()
-        f_kwargs = {'name': 'test-name'}
+        f_kwargs = {"name": "test-name"}
         wait_cls.return_value.wait.side_effect = EsWaitTimeout(
-            'timeout error', 10.0, 10.0
+            "timeout error", 10.0, 10.0
         )
         with pytest.raises(
-            TestbedFailure, match='timeout error. Elapsed time: 10.0. Timeout: 10.0'
+            TestbedFailure, match="timeout error. Elapsed time: 10.0. Timeout: 10.0"
         ):
             wait_wrapper(client, wait_cls, wait_kwargs, func, f_kwargs)
 
     def test_wait_wrapper_transport_error(self, client):
         wait_cls = MagicMock()
-        wait_kwargs = {'name': 'test-name', 'kind': 'index', 'pause': 1}
+        wait_kwargs = {"name": "test-name", "kind": "index", "pause": 1}
         func = MagicMock()
-        f_kwargs = {'name': 'test-name'}
-        func.side_effect = TransportError('error')
+        f_kwargs = {"name": "test-name"}
+        func.side_effect = TransportError("error")
         with pytest.raises(
             TestbedFailure,
-            match='Elasticsearch TransportError class exception encountered:',
+            match="Elasticsearch TransportError class exception encountered:",
         ):
             wait_wrapper(client, wait_cls, wait_kwargs, func, f_kwargs)
 
     def test_wait_wrapper_general_exception(self, client):
         wait_cls = MagicMock()
-        wait_kwargs = {'name': 'test-name', 'kind': 'index', 'pause': 1}
+        wait_kwargs = {"name": "test-name", "kind": "index", "pause": 1}
         func = MagicMock()
-        f_kwargs = {'name': 'test-name'}
-        err = 'general error'
+        f_kwargs = {"name": "test-name"}
+        err = "general error"
         msg = f"General Exception caught: \nException('{err}')"
         func.side_effect = Exception(err)
         with pytest.raises(TestbedFailure) as exc:
@@ -257,37 +257,37 @@ class TestIlmExplain:
 
     def test_ilm_explain(self, client):
         client.ilm.explain_lifecycle.return_value = {
-            'indices': {'test-index': {'phase': 'hot'}}
+            "indices": {"test-index": {"phase": "hot"}}
         }
-        result = ilm_explain(client, 'test-index')
-        assert result == {'phase': 'hot'}
+        result = ilm_explain(client, "test-index")
+        assert result == {"phase": "hot"}
 
     def test_ilm_explain_key_error(self, client, caplog):
         caplog.set_level(10)
         client.ilm.explain_lifecycle.return_value = {
-            'indices': {'new-index': {'phase': 'hot'}}
+            "indices": {"new-index": {"phase": "hot"}}
         }
         client.ilm.explain_lifecycle.side_effect = KeyError
         with pytest.raises(KeyError):
-            assert ilm_explain(client, 'test-index') == {'phase': 'hot'}
-            assert 'Index name changed' in caplog.text
+            assert ilm_explain(client, "test-index") == {"phase": "hot"}
+            assert "Index name changed" in caplog.text
 
     def test_ilm_explain_not_found_error(self, client, caplog, notfound):
         caplog.set_level(30)  # warning
         client.ilm.explain_lifecycle.side_effect = notfound
         with pytest.raises(NameChanged):
-            ilm_explain(client, 'test-index')
+            ilm_explain(client, "test-index")
             assert (
                 "Datastream/Index Name changed. test-index was not found" in caplog.text
             )
 
     def test_ilm_explain_general_exception(self, client):
-        client.ilm.explain_lifecycle.side_effect = Exception('error')
-        with patch('es_testbed.es_api.logger.critical') as mock_critical:
+        client.ilm.explain_lifecycle.side_effect = Exception("error")
+        with patch("es_testbed.es_api.logger.critical") as mock_critical:
             with pytest.raises(ResultNotExpected):
-                ilm_explain(client, 'test-index')
+                ilm_explain(client, "test-index")
                 mock_critical.assert_called_once_with(
-                    'Unable to get ILM information for index test-index'
+                    "Unable to get ILM information for index test-index"
                 )
 
 
@@ -295,98 +295,98 @@ class TestExists:
 
     def test_exists_snapshot(self, client):
         client.snapshot.get.return_value = {
-            'snapshots': [{'snapshot': 'test-snapshot'}]
+            "snapshots": [{"snapshot": "test-snapshot"}]
         }
-        assert exists(client, 'snapshot', 'test-snapshot', repository='test-repo')
+        assert exists(client, "snapshot", "test-snapshot", repository="test-repo")
         client.snapshot.get.assert_called_once_with(
-            snapshot='test-snapshot', repository='test-repo'
+            snapshot="test-snapshot", repository="test-repo"
         )
 
     def test_exists_ilm(self, client):
-        client.ilm.get_lifecycle.return_value = {'test-ilm': {}}
-        assert exists(client, 'ilm', 'test-ilm')
-        client.ilm.get_lifecycle.assert_called_once_with(name='test-ilm')
+        client.ilm.get_lifecycle.return_value = {"test-ilm": {}}
+        assert exists(client, "ilm", "test-ilm")
+        client.ilm.get_lifecycle.assert_called_once_with(name="test-ilm")
 
     def test_exists_index(self, client):
         client.indices.exists.return_value = True
-        assert exists(client, 'index', 'test-index')
-        client.indices.exists.assert_called_once_with(index='test-index')
+        assert exists(client, "index", "test-index")
+        client.indices.exists.assert_called_once_with(index="test-index")
 
     def test_exists_data_stream(self, client):
         client.indices.exists.return_value = True
-        assert exists(client, 'data_stream', 'test-data-stream')
-        client.indices.exists.assert_called_once_with(index='test-data-stream')
+        assert exists(client, "data_stream", "test-data-stream")
+        client.indices.exists.assert_called_once_with(index="test-data-stream")
 
     def test_exists_template(self, client):
         client.indices.exists_index_template.return_value = True
-        assert exists(client, 'template', 'test-template')
+        assert exists(client, "template", "test-template")
         client.indices.exists_index_template.assert_called_once_with(
-            name='test-template'
+            name="test-template"
         )
 
     def test_exists_component(self, client):
         client.cluster.exists_component_template.return_value = True
-        assert exists(client, 'component', 'test-component')
+        assert exists(client, "component", "test-component")
         client.cluster.exists_component_template.assert_called_once_with(
-            name='test-component'
+            name="test-component"
         )
 
     def test_exists_not_found_error(self, client, notfound):
         client.indices.exists.side_effect = notfound
-        assert not exists(client, 'index', 'test-index')
+        assert not exists(client, "index", "test-index")
 
     def test_exists_general_exception(self, client):
-        client.indices.exists.side_effect = Exception('error')
+        client.indices.exists.side_effect = Exception("error")
         with pytest.raises(ResultNotExpected):
-            exists(client, 'index', 'test-index')
+            exists(client, "index", "test-index")
 
     def test_exists_no_name(self, client):
-        assert not exists(client, 'index', None)
+        assert not exists(client, "index", None)
 
 
 class TestDelete:
 
     def test_delete_snapshot_success(self, client):
-        client.snapshot.delete.return_value = {'acknowledged': True}
-        assert delete(client, 'snapshot', 'test-snapshot', repository='test-repo')
+        client.snapshot.delete.return_value = {"acknowledged": True}
+        assert delete(client, "snapshot", "test-snapshot", repository="test-repo")
 
     def test_delete_index_success(self, client):
-        client.indices.delete.return_value = {'acknowledged': True}
-        assert delete(client, 'index', 'test-index')
+        client.indices.delete.return_value = {"acknowledged": True}
+        assert delete(client, "index", "test-index")
 
     def test_delete_template_success(self, client):
-        client.indices.delete_index_template.return_value = {'acknowledged': True}
-        assert delete(client, 'template', 'test-template')
+        client.indices.delete_index_template.return_value = {"acknowledged": True}
+        assert delete(client, "template", "test-template")
 
     def test_delete_component_success(self, client):
-        client.cluster.delete_component_template.return_value = {'acknowledged': True}
-        assert delete(client, 'component', 'test-component')
+        client.cluster.delete_component_template.return_value = {"acknowledged": True}
+        assert delete(client, "component", "test-component")
 
     def test_delete_ilm_success(self, client):
-        client.ilm.delete_lifecycle.return_value = {'acknowledged': True}
-        assert delete(client, 'ilm', 'test-ilm')
+        client.ilm.delete_lifecycle.return_value = {"acknowledged": True}
+        assert delete(client, "ilm", "test-ilm")
 
     def test_delete_not_found_error(self, client, notfound):
         client.indices.delete.side_effect = notfound
-        with patch('es_testbed.es_api.logger.warning'):
-            assert delete(client, 'index', 'test-index')
+        with patch("es_testbed.es_api.logger.warning"):
+            assert delete(client, "index", "test-index")
 
     def test_delete_general_exception(self, client):
-        client.indices.delete.side_effect = Exception('error')
+        client.indices.delete.side_effect = Exception("error")
         with pytest.raises(ResultNotExpected):
-            delete(client, 'index', 'test-index')
+            delete(client, "index", "test-index")
 
     def test_delete_verify_failure(self, client):
-        client.indices.delete.return_value = {'acknowledged': False}
-        with patch('es_testbed.es_api.verify', return_value=False) as mock_verify:
-            assert not delete(client, 'index', 'test-index')
+        client.indices.delete.return_value = {"acknowledged": False}
+        with patch("es_testbed.es_api.verify", return_value=False) as mock_verify:
+            assert not delete(client, "index", "test-index")
             mock_verify.assert_called_once_with(
-                client, 'index', 'test-index', repository=None
+                client, "index", "test-index", repository=None
             )
 
     def test_delete_none_name(self, client):
-        with patch('es_testbed.es_api.debug.lv3') as mock_debug:
-            assert not delete(client, 'index', None)
+        with patch("es_testbed.es_api.debug.lv3") as mock_debug:
+            assert not delete(client, "index", None)
             mock_debug.assert_has_calls([call('"index" has a None value for name')])
 
 
@@ -394,65 +394,65 @@ class TestGet:
 
     def test_get_snapshot_success(self, client):
         client.snapshot.get.return_value = {
-            'snapshots': [{'snapshot': 'test-snapshot'}]
+            "snapshots": [{"snapshot": "test-snapshot"}]
         }
-        result = get(client, 'snapshot', 'test-snapshot', repository='test-repo')
-        assert result == ['test-snapshot']
+        result = get(client, "snapshot", "test-snapshot", repository="test-repo")
+        assert result == ["test-snapshot"]
         client.snapshot.get.assert_called_once_with(
-            snapshot='test-snapshot', repository='test-repo'
+            snapshot="test-snapshot", repository="test-repo"
         )
 
     def test_get_index_success(self, client):
-        client.indices.get.return_value = {'test-index': {}}
-        result = get(client, 'index', 'test-index')
-        assert result == ['test-index']
+        client.indices.get.return_value = {"test-index": {}}
+        result = get(client, "index", "test-index")
+        assert result == ["test-index"]
 
     def test_get_template_success(self, client):
         client.indices.get_index_template.return_value = {
-            'index_templates': [{'name': 'test-template'}]
+            "index_templates": [{"name": "test-template"}]
         }
-        result = get(client, 'template', 'test-template')
-        assert result == ['test-template']
-        client.indices.get_index_template.assert_called_once_with(name='test-template')
+        result = get(client, "template", "test-template")
+        assert result == ["test-template"]
+        client.indices.get_index_template.assert_called_once_with(name="test-template")
 
     def test_get_component_success(self, client):
         client.cluster.get_component_template.return_value = {
-            'component_templates': [{'name': 'test-component'}]
+            "component_templates": [{"name": "test-component"}]
         }
-        result = get(client, 'component', 'test-component')
-        assert result == ['test-component']
+        result = get(client, "component", "test-component")
+        assert result == ["test-component"]
         client.cluster.get_component_template.assert_called_once_with(
-            name='test-component'
+            name="test-component"
         )
 
     def test_get_ilm_success(self, client):
-        client.ilm.get_lifecycle.return_value = {'test-ilm': {}}
-        result = get(client, 'ilm', 'test-ilm')
-        assert result == ['test-ilm']
-        client.ilm.get_lifecycle.assert_called_once_with(name='test-ilm')
+        client.ilm.get_lifecycle.return_value = {"test-ilm": {}}
+        result = get(client, "ilm", "test-ilm")
+        assert result == ["test-ilm"]
+        client.ilm.get_lifecycle.assert_called_once_with(name="test-ilm")
 
     def test_get_data_stream_success(self, client):
         client.indices.get_data_stream.return_value = {
-            'data_streams': [{'name': 'test-data-stream'}]
+            "data_streams": [{"name": "test-data-stream"}]
         }
-        result = get(client, 'data_stream', 'test-data-stream')
-        assert result == ['test-data-stream']
+        result = get(client, "data_stream", "test-data-stream")
+        assert result == ["test-data-stream"]
         client.indices.get_data_stream.assert_called_once_with(
-            name='test-data-stream', expand_wildcards=['open', 'closed']
+            name="test-data-stream", expand_wildcards=["open", "closed"]
         )
 
     def test_get_not_found_error(self, client, notfound):
         client.indices.get.side_effect = notfound
-        assert get(client, 'index', 'test-index') == []
+        assert get(client, "index", "test-index") == []
 
     def test_get_general_exception(self, client):
-        client.indices.get.side_effect = Exception('error')
+        client.indices.get.side_effect = Exception("error")
         with pytest.raises(ResultNotExpected):
-            get(client, 'index', 'test-index')
+            get(client, "index", "test-index")
 
     def test_get_pattern_is_none(self, client, caplog):
         caplog.set_level(40)
-        kind = 'template'
+        kind = "template"
         with pytest.raises(TestbedMisconfig):
             get(client, kind, None)
             assert f'"{kind}" has a None value for pattern' in caplog.text

--- a/tests/unit/test_ilm.py
+++ b/tests/unit/test_ilm.py
@@ -24,82 +24,82 @@ PAUSE_VALUE = float(getenv(PAUSE_ENVVAR, default=PAUSE_DEFAULT))
 TIMEOUT_VALUE = float(getenv(TIMEOUT_ENVVAR, default=TIMEOUT_DEFAULT))
 
 RESOLVER = {
-    'indices': [{'name': INDEX1}],
-    'aliases': [],
-    'data_streams': [],
+    "indices": [{"name": INDEX1}],
+    "aliases": [],
+    "data_streams": [],
 }
 
 
 # Test Initialization
-@patch('es_testbed.ilm.resolver')
-@patch('es_testbed.ilm.ilm_explain')
-@patch('es_testbed.ilm.get_ilm_phases')
+@patch("es_testbed.ilm.resolver")
+@patch("es_testbed.ilm.ilm_explain")
+@patch("es_testbed.ilm.get_ilm_phases")
 def test_init(mock_get_ilm_phases, mock_ilm_explain, mock_resolver, client):
     mock_resolver.return_value = RESOLVER
     mock_ilm_explain.return_value = {
-        'phase': 'hot',
-        'action': 'complete',
-        'step': 'complete',
+        "phase": "hot",
+        "action": "complete",
+        "step": "complete",
     }
-    mock_get_ilm_phases.return_value = {'hot': {}, 'warm': {}, 'delete': {}}
+    mock_get_ilm_phases.return_value = {"hot": {}, "warm": {}, "delete": {}}
 
     tracker = IlmTracker(client, INDEX1)
 
     assert tracker.name == INDEX1
-    assert tracker._explain.phase == 'hot'
-    assert tracker._phases == {'hot': {}, 'warm': {}, 'delete': {}}
+    assert tracker._explain.phase == "hot"
+    assert tracker._phases == {"hot": {}, "warm": {}, "delete": {}}
 
 
 # Test Properties
 def test_current_step(tracker):
     tracker._explain = DotMap(
-        {'phase': 'hot', 'action': 'rollover', 'step': 'check-rollover'}
+        {"phase": "hot", "action": "rollover", "step": "check-rollover"}
     )
-    with patch.object(tracker, 'update'):  # Mock update to avoid external call
+    with patch.object(tracker, "update"):  # Mock update to avoid external call
         assert tracker.current_step() == {
-            'phase': 'hot',
-            'action': 'rollover',
-            'name': 'check-rollover',
+            "phase": "hot",
+            "action": "rollover",
+            "name": "check-rollover",
         }
 
 
 def test_explain(tracker):
-    tracker._explain = DotMap({'phase': 'hot'})
-    assert tracker.explain == DotMap({'phase': 'hot'})
+    tracker._explain = DotMap({"phase": "hot"})
+    assert tracker.explain == DotMap({"phase": "hot"})
 
 
 def test_next_phase(tracker):
-    tracker._explain = DotMap({'phase': 'hot'})
-    tracker._phases = {'hot': {}, 'warm': {}, 'delete': {}}
-    assert tracker.next_phase() == 'warm'
+    tracker._explain = DotMap({"phase": "hot"})
+    tracker._phases = {"hot": {}, "warm": {}, "delete": {}}
+    assert tracker.next_phase() == "warm"
 
-    tracker._explain.phase = 'warm'
-    assert tracker.next_phase() == 'delete'
+    tracker._explain.phase = "warm"
+    assert tracker.next_phase() == "delete"
 
-    tracker._explain.phase = 'delete'
+    tracker._explain.phase = "delete"
     assert tracker.next_phase() is None
 
 
 def test_policy_phases(tracker):
-    tracker._phases = {'hot': {}, 'warm': {}, 'delete': {}}
-    assert tracker.policy_phases == ['hot', 'warm', 'delete']
+    tracker._phases = {"hot": {}, "warm": {}, "delete": {}}
+    assert tracker.policy_phases == ["hot", "warm", "delete"]
 
 
 # Test Advance Method
-@patch('es_testbed.ilm.IlmPhase')
-@patch('es_testbed.ilm.IlmStep')
-@patch('es_testbed.ilm.ilm_explain')
+@patch("es_testbed.ilm.IlmPhase")
+@patch("es_testbed.ilm.IlmStep")
+@patch("es_testbed.ilm.ilm_explain")
 def test_advance_to_warm(mock_ilm_explain, mock_ilm_step, mock_ilm_phase, client):
     mock_ilm_explain.side_effect = [
-        {'phase': 'hot', 'action': 'complete', 'step': 'complete'},
-        {'phase': 'warm', 'action': 'incomplete', 'step': 'incomplete'},
-        {'phase': 'warm', 'action': 'complete', 'step': 'complete'},
+        {"phase": "hot", "action": "complete", "step": "complete"},
+        {"phase": "warm", "action": "incomplete", "step": "incomplete"},
+        {"phase": "warm", "action": "complete", "step": "complete"},
     ]
     with patch(
-        'es_testbed.ilm.get_ilm_phases',
-        return_value={'hot': {}, 'warm': {}, 'delete': {}},
+        "es_testbed.ilm.get_ilm_phases",
+        return_value={"hot": {}, "warm": {}, "delete": {}},
     ):
-        with patch('es_testbed.ilm.resolver', return_value=RESOLVER):
+        with patch("es_testbed.ilm.resolver", return_value=RESOLVER):
             tracker = IlmTracker(client, INDEX1)
 
     mock_phase_instance = MagicMock()
@@ -107,122 +107,122 @@ def test_advance_to_warm(mock_ilm_explain, mock_ilm_step, mock_ilm_phase, client
     mock_step_instance = MagicMock()
     mock_ilm_step.return_value = mock_step_instance
 
-    tracker.advance(phase='warm')
+    tracker.advance(phase="warm")
 
     assert tracker.current_step() == {
-        'phase': 'warm',
-        'action': 'complete',
-        'name': 'complete',
+        "phase": "warm",
+        "action": "complete",
+        "name": "complete",
     }
 
 
 # Test Next Step
 def test_next_step(tracker):
-    tracker._phases = {'hot': {}, 'warm': {}, 'delete': {}}
+    tracker._phases = {"hot": {}, "warm": {}, "delete": {}}
 
-    assert tracker.next_step(phase='warm') == {'phase': 'warm'}
-    assert tracker.next_step(phase='warm', action='some_action', name='some_step') == {
-        'phase': 'warm',
-        'action': 'some_action',
-        'name': 'some_step',
+    assert tracker.next_step(phase="warm") == {"phase": "warm"}
+    assert tracker.next_step(phase="warm", action="some_action", name="some_step") == {
+        "phase": "warm",
+        "action": "some_action",
+        "name": "some_step",
     }
 
     with pytest.raises(TestbedMisconfig):
-        tracker.next_step(phase='warm', action='some_action')
+        tracker.next_step(phase="warm", action="some_action")
 
     with pytest.raises(TestbedMisconfig):
-        tracker.next_step(phase='warm', name='some_step')
+        tracker.next_step(phase="warm", name="some_step")
 
 
 # Test Phase Number and Name Mappings
 def test_pnum_pname(tracker):
-    assert tracker.pnum('new') == 0
-    assert tracker.pnum('hot') == 1
-    assert tracker.pnum('warm') == 2
-    assert tracker.pnum('cold') == 3
-    assert tracker.pnum('frozen') == 4
-    assert tracker.pnum('delete') == 5
+    assert tracker.pnum("new") == 0
+    assert tracker.pnum("hot") == 1
+    assert tracker.pnum("warm") == 2
+    assert tracker.pnum("cold") == 3
+    assert tracker.pnum("frozen") == 4
+    assert tracker.pnum("delete") == 5
 
-    assert tracker.pname(0) == 'new'
-    assert tracker.pname(1) == 'hot'
-    assert tracker.pname(2) == 'warm'
-    assert tracker.pname(3) == 'cold'
-    assert tracker.pname(4) == 'frozen'
-    assert tracker.pname(5) == 'delete'
+    assert tracker.pname(0) == "new"
+    assert tracker.pname(1) == "hot"
+    assert tracker.pname(2) == "warm"
+    assert tracker.pname(3) == "cold"
+    assert tracker.pname(4) == "frozen"
+    assert tracker.pname(5) == "delete"
 
 
 # Test Resolve
-@patch('es_testbed.ilm.resolver')
+@patch("es_testbed.ilm.resolver")
 def test_resolve(mock_resolver, client):
 
     mock_resolver.return_value = {
-        'indices': [{'name': INDEX1}],
-        'aliases': [],
-        'data_streams': [],
+        "indices": [{"name": INDEX1}],
+        "aliases": [],
+        "data_streams": [],
     }
-    with patch('es_testbed.ilm.ilm_explain', return_value={'phase': 'hot'}):
-        with patch('es_testbed.ilm.get_ilm_phases', return_value={'hot': {}}):
+    with patch("es_testbed.ilm.ilm_explain", return_value={"phase": "hot"}):
+        with patch("es_testbed.ilm.get_ilm_phases", return_value={"hot": {}}):
             assert IlmTracker(client, INDEX1).name == INDEX1
 
     mock_resolver.return_value = {
-        'indices': [],
-        'aliases': ['test_alias'],
-        'data_streams': [],
+        "indices": [],
+        "aliases": ["test_alias"],
+        "data_streams": [],
     }
     with pytest.raises(ResultNotExpected):
-        IlmTracker(client, 'test_alias')
+        IlmTracker(client, "test_alias")
 
     mock_resolver.return_value = {
-        'indices': [],
-        'aliases': [],
-        'data_streams': ['test_ds'],
+        "indices": [],
+        "aliases": [],
+        "data_streams": ["test_ds"],
     }
     with pytest.raises(ResultNotExpected):
-        IlmTracker(client, 'test_ds')
+        IlmTracker(client, "test_ds")
 
     mock_resolver.return_value = {
-        'indices': [{'name': 'index1'}, {'name': 'index2'}],
-        'aliases': [],
-        'data_streams': [],
+        "indices": [{"name": "index1"}, {"name": "index2"}],
+        "aliases": [],
+        "data_streams": [],
     }
     with pytest.raises(ResultNotExpected):
-        IlmTracker(client, 'index*')
+        IlmTracker(client, "index*")
 
 
 # Test Update
-@patch('es_testbed.ilm.ilm_explain')
+@patch("es_testbed.ilm.ilm_explain")
 def test_update(mock_ilm_explain, tracker):
     mock_ilm_explain.return_value = {
-        'phase': 'warm',
-        'action': 'complete',
-        'step': 'complete',
+        "phase": "warm",
+        "action": "complete",
+        "step": "complete",
     }
-    tracker._explain = DotMap({'phase': 'hot'})
+    tracker._explain = DotMap({"phase": "hot"})
 
     tracker.update()
 
-    assert tracker._explain.phase == 'warm'
+    assert tracker._explain.phase == "warm"
 
 
-@patch('es_testbed.ilm.ilm_explain')
+@patch("es_testbed.ilm.ilm_explain")
 def test_update_name_changed(mock_ilm_explain, tracker):
-    mock_ilm_explain.side_effect = NameChanged('Name changed')
+    mock_ilm_explain.side_effect = NameChanged("Name changed")
 
     with pytest.raises(NameChanged):
         tracker.update()
 
 
 # Test Wait for Complete
-@patch('es_testbed.ilm.IlmStep')
+@patch("es_testbed.ilm.IlmStep")
 def test_wait4complete(mock_ilm_step, tracker):
     tracker._explain = DotMap(
-        {'phase': 'hot', 'action': 'complete', 'step': 'complete'}
+        {"phase": "hot", "action": "complete", "step": "complete"}
     )
     tracker.wait4complete()
     mock_ilm_step.assert_not_called()
 
     tracker._explain = DotMap(
-        {'phase': 'warm', 'action': 'incomplete', 'step': 'incomplete'}
+        {"phase": "warm", "action": "incomplete", "step": "incomplete"}
     )
     mock_step_instance = MagicMock()
     mock_ilm_step.return_value = mock_step_instance
@@ -236,40 +236,40 @@ def test_wait4complete(mock_ilm_step, tracker):
 
 
 # Test Get Explain Data
-@patch('es_testbed.ilm.ilm_explain')
+@patch("es_testbed.ilm.ilm_explain")
 def test_get_explain_data(mock_ilm_explain, tracker):
-    mock_ilm_explain.return_value = {'phase': 'hot'}
-    assert tracker.get_explain_data() == {'phase': 'hot'}
+    mock_ilm_explain.return_value = {"phase": "hot"}
+    assert tracker.get_explain_data() == {"phase": "hot"}
 
 
-@patch('es_testbed.ilm.ilm_explain')
+@patch("es_testbed.ilm.ilm_explain")
 def test_get_explain_data_name_changed(mock_ilm_explain, tracker):
-    mock_ilm_explain.side_effect = NameChanged('Name changed')
+    mock_ilm_explain.side_effect = NameChanged("Name changed")
     with pytest.raises(NameChanged):
         tracker.get_explain_data()
 
 
-@patch('es_testbed.ilm.ilm_explain')
+@patch("es_testbed.ilm.ilm_explain")
 def test_get_explain_data_raises(mock_ilm_explain, tracker):
-    mock_ilm_explain.side_effect = ResultNotExpected('error')
+    mock_ilm_explain.side_effect = ResultNotExpected("error")
     with pytest.raises(ResultNotExpected):
         tracker.get_explain_data()
 
 
 # Test successful phase wait
-@patch('es_testbed.ilm.IlmPhase')
+@patch("es_testbed.ilm.IlmPhase")
 def test_phase_wait_success(mock_ilm_phase, tracker):
     """Test _phase_wait when the phase is reached successfully."""
     mock_phase_instance = MagicMock()
     mock_ilm_phase.return_value = mock_phase_instance
     mock_phase_instance.wait.return_value = None  # Simulate successful wait
 
-    tracker._phase_wait('warm')
+    tracker._phase_wait("warm")
 
     mock_ilm_phase.assert_called_once_with(
         tracker.client,
         name=INDEX1,
-        phase='warm',
+        phase="warm",
         pause=PAUSE_VALUE,
         timeout=TIMEOUT_VALUE,
     )
@@ -277,23 +277,23 @@ def test_phase_wait_success(mock_ilm_phase, tracker):
 
 
 # Test phase wait with timeout
-@patch('es_testbed.ilm.IlmPhase')
+@patch("es_testbed.ilm.IlmPhase")
 def test_phase_wait_timeout(mock_ilm_phase, tracker):
     """Test _phase_wait when a timeout occurs."""
     mock_phase_instance = MagicMock()
     mock_ilm_phase.return_value = mock_phase_instance
     mock_phase_instance.wait.side_effect = EsWaitTimeout(
-        'Timeout waiting for phase', 30.5, TIMEOUT_VALUE
+        "Timeout waiting for phase", 30.5, TIMEOUT_VALUE
     )
 
     with pytest.raises(TestbedFailure) as exc_info:
-        tracker._phase_wait('warm')
+        tracker._phase_wait("warm")
 
-    assert 'Timeout waiting for phase' in str(exc_info.value)
+    assert "Timeout waiting for phase" in str(exc_info.value)
     mock_ilm_phase.assert_called_once_with(
         tracker.client,
         name=INDEX1,
-        phase='warm',
+        phase="warm",
         pause=PAUSE_VALUE,
         timeout=TIMEOUT_VALUE,
     )
@@ -301,21 +301,21 @@ def test_phase_wait_timeout(mock_ilm_phase, tracker):
 
 
 # Test phase wait with fatal error
-@patch('es_testbed.ilm.IlmPhase')
+@patch("es_testbed.ilm.IlmPhase")
 def test_phase_wait_fatal_error(mock_ilm_phase, tracker):
     """Test _phase_wait when a fatal error occurs."""
     mock_phase_instance = MagicMock()
     mock_ilm_phase.return_value = mock_phase_instance
-    mock_phase_instance.wait.side_effect = EsWaitFatal('Fatal error during wait', 30.5)
+    mock_phase_instance.wait.side_effect = EsWaitFatal("Fatal error during wait", 30.5)
 
     with pytest.raises(TestbedFailure) as exc_info:
-        tracker._phase_wait('warm')
+        tracker._phase_wait("warm")
 
-    assert 'Fatal error during wait' in str(exc_info.value)
+    assert "Fatal error during wait" in str(exc_info.value)
     mock_ilm_phase.assert_called_once_with(
         tracker.client,
         name=INDEX1,
-        phase='warm',
+        phase="warm",
         pause=PAUSE_VALUE,
         timeout=TIMEOUT_VALUE,
     )
@@ -326,20 +326,20 @@ def test_phase_wait_fatal_error(mock_ilm_phase, tracker):
 def test_wait4complete_already_complete(tracker):
     """Test wait4complete when the ILM step is already complete."""
     tracker._explain = MagicMock()
-    tracker._explain.action = 'complete'
-    tracker._explain.step = 'complete'
-    with patch('es_testbed.ilm.IlmStep') as mock_ilm_step:
+    tracker._explain.action = "complete"
+    tracker._explain.step = "complete"
+    with patch("es_testbed.ilm.IlmStep") as mock_ilm_step:
         tracker.wait4complete()
         mock_ilm_step.assert_not_called()
 
 
 # Test wait4complete when the step is not complete and wait succeeds
-@patch('es_testbed.ilm.IlmStep')
+@patch("es_testbed.ilm.IlmStep")
 def test_wait4complete_not_complete_success(mock_ilm_step, tracker):
     """Test wait4complete when the step is not complete and the wait succeeds."""
     tracker._explain = MagicMock()
-    tracker._explain.action = 'incomplete'
-    tracker._explain.step = 'incomplete'
+    tracker._explain.action = "incomplete"
+    tracker._explain.step = "incomplete"
     mock_step_instance = MagicMock()
     mock_ilm_step.return_value = mock_step_instance
     mock_step_instance.wait.return_value = None  # Simulate successful wait
@@ -353,22 +353,22 @@ def test_wait4complete_not_complete_success(mock_ilm_step, tracker):
 
 
 # Test wait4complete when the step is not complete and wait times out
-@patch('es_testbed.ilm.IlmStep')
+@patch("es_testbed.ilm.IlmStep")
 def test_wait4complete_not_complete_timeout(mock_ilm_step, tracker):
     """Test wait4complete when the step is not complete and the wait times out."""
     tracker._explain = MagicMock()
-    tracker._explain.action = 'some_action'
-    tracker._explain.step = 'some_step'
+    tracker._explain.action = "some_action"
+    tracker._explain.step = "some_step"
     mock_step_instance = MagicMock()
     mock_ilm_step.return_value = mock_step_instance
     mock_step_instance.wait.side_effect = EsWaitTimeout(
-        'Timeout waiting for step', 30.5, TIMEOUT_VALUE
+        "Timeout waiting for step", 30.5, TIMEOUT_VALUE
     )
 
     with pytest.raises(TestbedFailure) as exc_info:
         tracker.wait4complete()
 
-    assert 'Timeout waiting for step' in str(exc_info.value)
+    assert "Timeout waiting for step" in str(exc_info.value)
     mock_ilm_step.assert_called_once_with(
         tracker.client, name=INDEX1, pause=PAUSE_VALUE, timeout=TIMEOUT_VALUE
     )
@@ -376,22 +376,22 @@ def test_wait4complete_not_complete_timeout(mock_ilm_step, tracker):
 
 
 # Test wait4complete when the step is not complete and wait encounters a fatal error
-@patch('es_testbed.ilm.IlmStep')
+@patch("es_testbed.ilm.IlmStep")
 def test_wait4complete_not_complete_fatal_error(mock_ilm_step, tracker):
     """Test wait4complete when the step is not complete and a fatal error occurs."""
     tracker._explain = MagicMock()
-    tracker._explain.action = 'some_action'
-    tracker._explain.step = 'some_step'
+    tracker._explain.action = "some_action"
+    tracker._explain.step = "some_step"
     mock_step_instance = MagicMock()
     mock_ilm_step.return_value = mock_step_instance
     mock_step_instance.wait.side_effect = EsWaitFatal(
-        'Fatal error during wait', TIMEOUT_VALUE
+        "Fatal error during wait", TIMEOUT_VALUE
     )
 
     with pytest.raises(TestbedFailure) as exc_info:
         tracker.wait4complete()
 
-    assert 'Fatal error during wait' in str(exc_info.value)
+    assert "Fatal error during wait" in str(exc_info.value)
     mock_ilm_step.assert_called_once_with(
         tracker.client, name=INDEX1, pause=PAUSE_VALUE, timeout=TIMEOUT_VALUE
     )
@@ -404,12 +404,12 @@ def test_advance_already_on_delete_phase(tracker_adv):
     """
     tracker_adv._explain.phase = "delete"
 
-    with patch('es_testbed.es_api.ilm_move') as mock_ilm_move, patch.object(
+    with patch("es_testbed.es_api.ilm_move") as mock_ilm_move, patch.object(
         tracker_adv, "_phase_wait"
     ) as mock_phase_wait, patch.object(
         tracker_adv, "wait4complete"
     ) as mock_wait4complete, patch(
-        'es_testbed.ilm.debug.lv1'
+        "es_testbed.ilm.debug.lv1"
     ) as mock_debug:
 
         tracker_adv.advance(phase="warm")
@@ -426,13 +426,13 @@ def test_advance_already_on_delete_phase(tracker_adv):
 def test_advance_from_new_to_hot(tracker_adv):
     """Test advancing from 'new' to 'hot' phase, only waiting for the phase."""
     tracker_adv._explain.phase = "new"
-    expected = 'hot'
-    with patch('es_testbed.es_api.ilm_move') as mock_ilm_move, patch.object(
+    expected = "hot"
+    with patch("es_testbed.es_api.ilm_move") as mock_ilm_move, patch.object(
         tracker_adv, "_phase_wait"
     ) as mock_phase_wait, patch.object(
         tracker_adv, "wait4complete"
     ) as mock_wait4complete, patch(
-        'es_testbed.ilm.debug.lv2'
+        "es_testbed.ilm.debug.lv2"
     ) as mock_debug:
 
         tracker_adv.advance(phase=expected)
@@ -447,18 +447,18 @@ def test_advance_from_new_to_hot(tracker_adv):
 def test_advance_beyond_hot_to_warm(tracker_adv, caplog):
     """Test advancing from 'hot' to 'warm' phase with step completion."""
     caplog.set_level(logging.DEBUG)
-    start, end = 'hot', 'warm'
+    start, end = "hot", "warm"
     with debug.change_level(3):
         tracker_adv._explain.phase = start
-        with patch('es_testbed.es_api.ilm_move'), patch(
-            'es_testbed.ilm.IlmTracker.next_phase', return_value=end
+        with patch("es_testbed.es_api.ilm_move"), patch(
+            "es_testbed.ilm.IlmTracker.next_phase", return_value=end
         ), patch.object(tracker_adv, "update"), patch.object(
             tracker_adv, "wait4complete"
         ), patch.object(
             tracker_adv, "_phase_wait"
         ):
 
-            assert tracker_adv.current_step()['phase'] == start
+            assert tracker_adv.current_step()["phase"] == start
             tracker_adv.advance(phase=end)
             assert 'DEBUG3 Advancing to "warm" phase' in caplog.text
 
@@ -466,20 +466,20 @@ def test_advance_beyond_hot_to_warm(tracker_adv, caplog):
 def test_advance_already_on_target_phase(tracker_adv, caplog):
     """Test that advance does nothing when already on the target phase."""
     caplog.set_level(logging.DEBUG)
-    expected = 'warm'
-    step = {'phase': expected, 'action': 'complete', 'name': 'complete'}
+    expected = "warm"
+    step = {"phase": expected, "action": "complete", "name": "complete"}
     with debug.change_level(3):
         tracker_adv._explain.phase = expected
-        tracker_adv._explain.action = 'complete'
-        tracker_adv._explain.step = 'complete'
+        tracker_adv._explain.action = "complete"
+        tracker_adv._explain.step = "complete"
 
-        with patch('es_testbed.es_api.ilm_move') as mock_ilm_move, patch(
-            'es_testbed.ilm.ilm_explain',
-            return_value={'phase': expected, 'action': 'complete', 'step': 'complete'},
+        with patch("es_testbed.es_api.ilm_move") as mock_ilm_move, patch(
+            "es_testbed.ilm.ilm_explain",
+            return_value={"phase": expected, "action": "complete", "step": "complete"},
         ), patch(
-            'es_testbed.ilm.IlmTracker.current_step', return_value=step
+            "es_testbed.ilm.IlmTracker.current_step", return_value=step
         ), patch.object(
-            tracker_adv, 'next_phase', return_value=expected
+            tracker_adv, "next_phase", return_value=expected
         ), patch.object(
             tracker_adv, "_phase_wait"
         ) as mock_phase_wait, patch.object(
@@ -503,7 +503,7 @@ def test_advance_phase_wait_error_handling(tracker_adv, caplog):
     caplog.set_level(logging.DEBUG)
     tracker_adv._explain.phase = "hot"
 
-    with patch('es_testbed.es_api.ilm_move'), patch.object(
+    with patch("es_testbed.es_api.ilm_move"), patch.object(
         tracker_adv, "_phase_wait"
     ) as mock_phase_wait, patch.object(
         tracker_adv, "wait4complete"
@@ -522,5 +522,5 @@ def test_advance_phase_wait_error_handling(tracker_adv, caplog):
 
 def test_next_step_no_phase(tracker):
     """Test next_step when no phase is provided."""
-    with patch.object(tracker, 'next_phase', return_value='warm'):
-        assert tracker.next_step(phase=None) == {'phase': 'warm'}
+    with patch.object(tracker, "next_phase", return_value="warm"):
+        assert tracker.next_step(phase=None) == {"phase": "warm"}

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -10,12 +10,12 @@ from es_testbed._plan import PlanBuilder
 def test_plan_builder_init(plan_builder, settings):
     """Test PlanBuilder initialization."""
     assert plan_builder.settings == settings
-    assert plan_builder._plan.cleanup == 'UNSET'
+    assert plan_builder._plan.cleanup == "UNSET"
 
 
 def test_plan_builder_init_no_settings():
     """Test PlanBuilder initialization without settings."""
-    with pytest.raises(ValueError, match='Must provide a settings dictionary'):
+    with pytest.raises(ValueError, match="Must provide a settings dictionary"):
         PlanBuilder(settings=None)
 
 
@@ -28,19 +28,19 @@ def test_plan_builder_autoset(settings):
     """Test PlanBuilder initialization with autobuild."""
     plan_builder = PlanBuilder(settings=settings, autobuild=True)
     assert plan_builder.settings == settings
-    assert plan_builder._plan.cleanup == 'UNSET'
+    assert plan_builder._plan.cleanup == "UNSET"
 
 
 def test_create_lists(plan_builder):
     """Test PlanBuilder _create_lists method."""
     plan_builder._create_lists()
     for name in [
-        'indices',
-        'data_stream',
-        'snapshots',
-        'ilm_policies',
-        'index_templates',
-        'component_templates',
+        "indices",
+        "data_stream",
+        "snapshots",
+        "ilm_policies",
+        "index_templates",
+        "component_templates",
     ]:
         assert name in plan_builder._plan
         assert plan_builder._plan[name] == []
@@ -48,14 +48,14 @@ def test_create_lists(plan_builder):
 
 def test_setup(plan_builder):
     """Test PlanBuilder setup method."""
-    with patch('es_testbed._plan.randomstr', return_value='randomstr'):
-        with patch.object(plan_builder, 'update') as mock_update:
+    with patch("es_testbed._plan.randomstr", return_value="randomstr"):
+        with patch.object(plan_builder, "update") as mock_update:
             with patch.object(
-                plan_builder, 'update_rollover_alias'
+                plan_builder, "update_rollover_alias"
             ) as mock_update_rollover_alias:
-                with patch.object(plan_builder, 'update_ilm') as mock_update_ilm:
+                with patch.object(plan_builder, "update_ilm") as mock_update_ilm:
                     plan_builder.setup()
-                    assert plan_builder._plan.uniq == 'randomstr'
+                    assert plan_builder._plan.uniq == "randomstr"
                     mock_update.assert_called_once_with(plan_builder.settings)
                     mock_update_rollover_alias.assert_called_once()
                     mock_update_ilm.assert_called_once()
@@ -63,42 +63,42 @@ def test_setup(plan_builder):
 
 def test_update(plan_builder):
     """Test PlanBuilder update method."""
-    new_settings = {'new_key': 'new_value'}
+    new_settings = {"new_key": "new_value"}
     plan_builder.update(new_settings)
-    assert plan_builder._plan.new_key == 'new_value'
+    assert plan_builder._plan.new_key == "new_value"
 
 
 def test_update_ilm(plan_builder):
     """Test PlanBuilder update_ilm method."""
-    plan_builder._plan.ilm = DotMap({'enabled': True, 'phases': ['hot']})
-    plan_builder._plan.index_buildlist = [{'searchable': 'warm'}]
-    with patch('es_testbed._plan.build_ilm_policy', return_value='ilm_policy'):
+    plan_builder._plan.ilm = DotMap({"enabled": True, "phases": ["hot"]})
+    plan_builder._plan.index_buildlist = [{"searchable": "warm"}]
+    with patch("es_testbed._plan.build_ilm_policy", return_value="ilm_policy"):
         plan_builder.update_ilm()
-        assert plan_builder._plan.ilm.policy == 'ilm_policy'
-        assert 'warm' in plan_builder._plan.ilm.phases
+        assert plan_builder._plan.ilm.policy == "ilm_policy"
+        assert "warm" in plan_builder._plan.ilm.phases
 
 
 def test_update_ilm_not_in_plan(plan_builder):
     """Test PlanBuilder update_ilm method when 'ilm' is not in the plan."""
-    plan_builder._plan.pop('ilm')
+    plan_builder._plan.pop("ilm")
     plan_builder.update_ilm()
     assert plan_builder._plan.ilm.enabled is False
-    assert plan_builder._plan.ilm.phases == ['hot', 'delete']
+    assert plan_builder._plan.ilm.phases == ["hot", "delete"]
 
 
 def test_update_ilm_ilm_is_bool(plan_builder):
     """Test PlanBuilder update_ilm method when 'ilm' is True"""
-    plan_builder._plan.pop('ilm')
+    plan_builder._plan.pop("ilm")
     plan_builder._plan.ilm = True
     plan_builder.update_ilm()
     assert plan_builder._plan.ilm.enabled is False
-    assert plan_builder._plan.ilm.phases == ['hot', 'delete']
+    assert plan_builder._plan.ilm.phases == ["hot", "delete"]
 
 
 def test_update_ilm_disabled(plan_builder):
     """Test PlanBuilder update_ilm method when ILM is disabled."""
-    plan_builder._plan.ilm = DotMap({'enabled': False})
-    with patch('es_testbed._plan.build_ilm_policy') as mock_build_ilm_policy:
+    plan_builder._plan.ilm = DotMap({"enabled": False})
+    with patch("es_testbed._plan.build_ilm_policy") as mock_build_ilm_policy:
         plan_builder.update_ilm()
         mock_build_ilm_policy.assert_not_called()
 
@@ -109,30 +109,30 @@ def test_update_ilm_no_phases(plan_builder):
     assert plan_builder.plan.ilm.enabled
     plan_builder.plan.ilm.phases = None  # Override the defaults to be empty
     plan_builder.update_ilm()
-    assert len(plan_builder._plan.ilm.policy['phases'].keys()) == 2
-    assert 'hot' in plan_builder._plan.ilm.policy['phases']
-    assert 'delete' in plan_builder._plan.ilm.policy['phases']
+    assert len(plan_builder._plan.ilm.policy["phases"].keys()) == 2
+    assert "hot" in plan_builder._plan.ilm.policy["phases"]
+    assert "delete" in plan_builder._plan.ilm.policy["phases"]
 
 
 def test_update_ilm_existing_phases(plan_builder):
     """Test PlanBuilder update_ilm method with existing phases."""
     plan_builder._plan.ilm.enabled = True
     plan_builder.update_ilm()
-    assert len(plan_builder._plan.ilm.policy['phases'].keys()) == 2
-    assert 'warm' not in plan_builder._plan.ilm.policy['phases']
-    plan_builder._plan.ilm.phases.append('warm')
+    assert len(plan_builder._plan.ilm.policy["phases"].keys()) == 2
+    assert "warm" not in plan_builder._plan.ilm.policy["phases"]
+    plan_builder._plan.ilm.phases.append("warm")
     plan_builder.update_ilm()
-    assert len(plan_builder._plan.ilm.policy['phases'].keys()) == 3
-    assert 'warm' in plan_builder._plan.ilm.policy['phases']
+    assert len(plan_builder._plan.ilm.policy["phases"].keys()) == 3
+    assert "warm" in plan_builder._plan.ilm.policy["phases"]
 
 
 def test_update_rollover_alias(plan_builder):
     """Test PlanBuilder update_rollover_alias method."""
-    plan_builder._plan.prefix = 'test-prefix'
-    plan_builder._plan.uniq = 'test-uniq'
+    plan_builder._plan.prefix = "test-prefix"
+    plan_builder._plan.uniq = "test-uniq"
     plan_builder._plan.rollover_alias = True
     plan_builder.update_rollover_alias()
-    assert plan_builder._plan.rollover_alias == 'test-prefix-idx-test-uniq'
+    assert plan_builder._plan.rollover_alias == "test-prefix-idx-test-uniq"
 
     plan_builder._plan.rollover_alias = False
     plan_builder.update_rollover_alias()


### PR DESCRIPTION
Turned on the Black formatter and let it go with double-quoted strings. Basically overwrote every. Single. File. Tests. Included.

Also: 

- Bumped dependency versions:
  - tiered-debug>=1.3.0
  - es_client>=8.18.2
  - es-wait>=0.15.1
- applied the new template to __init__.py, and 
- preemptively set up for ReadTheDocs (in the future)